### PR TITLE
[EDMT-259] auth 서비스 e2e 테스트 코드 작성 및 테스트 진행

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,5 +27,12 @@ export default defineConfig({
     command: 'pnpm dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
+    env: {
+      NEXT_PUBLIC_API_URL: 'https://dev-api.edukit.co.kr',
+      API_URL: 'https://dev-api.edukit.co.kr',
+      NEXT_PUBLIC_API_MOCKING: 'enabled',
+      NODE_ENV: 'development',
+      NEXT_PUBLIC_APP_ENV: 'development',
+    },
   },
 });

--- a/src/lib/msw-provider.tsx
+++ b/src/lib/msw-provider.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export const MSWProvider = ({ children }: { children: React.ReactNode }) => {
+  const UseMSW =
+    process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_API_MOCKING === 'enabled';
+
+  const [isReady, setIsReady] = useState(!UseMSW);
+
   useEffect(() => {
-    if (
-      process.env.NODE_ENV === 'development' &&
-      process.env.NEXT_PUBLIC_API_MOCKING === 'enabled'
-    ) {
-      import('@/mocks').then(({ initMsw }) => {
-        initMsw();
-      });
+    if (!UseMSW) {
+      return;
     }
-  }, []);
+
+    const init = async () => {
+      const { initMsw } = await import('@/mocks');
+      await initMsw();
+
+      setIsReady(true);
+    };
+
+    init();
+  }, [UseMSW]);
+
+  if (!isReady) {
+    return null;
+  }
 
   return <>{children}</>;
 };

--- a/src/mocks/handlers/auth/get-profile.ts
+++ b/src/mocks/handlers/auth/get-profile.ts
@@ -1,10 +1,37 @@
 import { http, HttpResponse } from 'msw';
 
 import { USER_INFO_DATA } from '@/constants/user-info-data';
+import { checkAccessToken } from '@/mocks/utils/check-access-token';
 import type { UserInfoTypes } from '@/types/api/auth';
 
 export const getProfile = [
-  http.get<never, { recordType: UserInfoTypes }>('/api/v1/users/profile', () => {
+  http.get<never, { recordType: UserInfoTypes }>('/api/v1/users/profile', ({ request }) => {
+    const authHeader = request.headers.get('Authorization');
+
+    const validation = checkAccessToken(authHeader);
+
+    if (!validation.isValid) {
+      return HttpResponse.json(
+        {
+          status: 401,
+          code: 'EDMT-4010101',
+          message: '유효하지 않은 토큰입니다.',
+        },
+        { status: 401 },
+      );
+    }
+
+    if (validation.isExpired) {
+      return HttpResponse.json(
+        {
+          status: 401,
+          code: 'EDMT-4010102',
+          message: '만료된 토큰입니다.',
+        },
+        { status: 401 },
+      );
+    }
+
     return HttpResponse.json(
       {
         status: 200,

--- a/src/mocks/handlers/auth/get-verify-email.ts
+++ b/src/mocks/handlers/auth/get-verify-email.ts
@@ -3,8 +3,8 @@ import { http, HttpResponse } from 'msw';
 export const getVerifyEmail = [
   http.get('/api/v1/auth/verify-email', ({ request }) => {
     const url = new URL(request.url);
-    const id = url.searchParams.get('id');
-    const code = url.searchParams.get('code');
+    const id = decodeURIComponent(url.searchParams.get('id') || '');
+    const code = decodeURIComponent(url.searchParams.get('code') || '');
 
     if (id === 'test@naver.com' && code === 'abc') {
       return HttpResponse.json({

--- a/src/mocks/handlers/auth/post-login.ts
+++ b/src/mocks/handlers/auth/post-login.ts
@@ -6,6 +6,8 @@ export const postLogin = [
   http.post('/api/v1/auth/login', async ({ request }) => {
     const { email, password } = (await request.json()) as LoginProp;
 
+    const expiresAt = Date.now() + 30 * 60 * 1000;
+
     if (email === 'admin@edukit.co.kr' && password === 'password1234') {
       return HttpResponse.json(
         {
@@ -13,11 +15,17 @@ export const postLogin = [
           code: 'EDMT-20002',
           message: '요청에 성공했습니다.',
           data: {
-            accessToken: 'admin-access-token',
+            accessToken: `admin-access-token.${expiresAt}`,
             isAdmin: true,
           },
         },
-        { status: 200 },
+        {
+          status: 200,
+          headers: {
+            'Content-type': 'application/json',
+            'Set-Cookie': 'refreshToken=admin-refresh-token; HttpOnly; Path=/; SameSite=Strict',
+          },
+        },
       );
     }
 
@@ -28,15 +36,21 @@ export const postLogin = [
           code: 'EDMT-20002',
           message: '요청에 성공했습니다.',
           data: {
-            accessToken: 'user-access-token',
+            accessToken: `user-access-token.${expiresAt}`,
             isAdmin: false,
           },
         },
-        { status: 200 },
+        {
+          status: 200,
+          headers: {
+            'Content-type': 'application/json',
+            'Set-Cookie': 'refreshToken=user-refresh-token; HttpOnly; Path=/; SameSite=Lax',
+          },
+        },
       );
     }
 
-    if (email === 'test@edukit.co.kr' && password !== 'password1234') {
+    if (email === 'test@edukit.co.kr' && password !== 'password1234!') {
       return HttpResponse.json(
         {
           status: 401,

--- a/src/mocks/handlers/auth/post-login.ts
+++ b/src/mocks/handlers/auth/post-login.ts
@@ -21,7 +21,7 @@ export const postLogin = [
       );
     }
 
-    if (email === 'test@edukit.co.kr' && password === 'password1234') {
+    if (email === 'test@edukit.co.kr' && password === 'password1234!') {
       return HttpResponse.json(
         {
           status: 200,
@@ -36,11 +36,22 @@ export const postLogin = [
       );
     }
 
+    if (email === 'test@edukit.co.kr' && password !== 'password1234') {
+      return HttpResponse.json(
+        {
+          status: 401,
+          code: 'EDMT-4010107',
+          message: '비밀번호가 일치하지 않습니다.',
+        },
+        { status: 401 },
+      );
+    }
+
     return HttpResponse.json(
       {
         status: 401,
         code: 'EDMT-4010107',
-        message: '비밀번호가 일치하지 않습니다.',
+        message: '존재하지 않는 회원입니다. 회원가입을 진행해주세요.',
       },
       { status: 401 },
     );

--- a/src/mocks/handlers/auth/reissue.ts
+++ b/src/mocks/handlers/auth/reissue.ts
@@ -1,19 +1,21 @@
 import { http, HttpResponse } from 'msw';
 
 export const reissue = [
-  http.patch('/api/v1/auth/reissue', ({ request }) => {
-    const cookieHeader = request.headers.get('cookie');
+  http.patch('/api/v1/auth/reissue', ({ cookies }) => {
+    const refreshToken = cookies['refreshToken'];
 
     let isAdmin = false;
     let accessToken = 'user-access-token';
 
-    if (cookieHeader?.includes('refreshToken=admin-refresh-token')) {
+    const expiresAt = Date.now() + 30 * 60 * 1000;
+
+    if (refreshToken === 'admin-refresh-token') {
       isAdmin = true;
-      accessToken = 'admin-access-token';
-    } else if (cookieHeader?.includes('refreshToken=user-refresh-token')) {
+      accessToken = `admin-access-token.${expiresAt}`;
+    } else if (refreshToken === 'user-refresh-token') {
       isAdmin = false;
-      accessToken = 'user-access-token';
-    } else if (!cookieHeader?.includes('refreshToken=')) {
+      accessToken = `user-access-token.${expiresAt}`;
+    } else {
       return HttpResponse.json(
         {
           status: 401,

--- a/src/mocks/handlers/auth/signup.ts
+++ b/src/mocks/handlers/auth/signup.ts
@@ -6,12 +6,12 @@ export const signup = [
   http.post('/api/v1/auth/signup', async ({ request }) => {
     const { email } = (await request.json()) as SignupTypes;
 
-    if (email === 'test@naver.com') {
+    if (email === 'test123@edukit.co.kr') {
       return HttpResponse.json(
         {
           status: 401,
           code: 'EDMT-40001',
-          message: '중복된 이메일입니다.',
+          message: '이미 등록된 회원입니다.',
         },
         { status: 401 },
       );

--- a/src/mocks/handlers/auth/signup.ts
+++ b/src/mocks/handlers/auth/signup.ts
@@ -17,10 +17,24 @@ export const signup = [
       );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-20002',
-      message: '요청에 성공했습니다.',
-    });
+    const expiresAt = Date.now() + 30 * 60 * 1000;
+
+    return HttpResponse.json(
+      {
+        status: 200,
+        code: 'EDMT-20002',
+        message: '요청에 성공했습니다.',
+        data: {
+          accessToken: `user-access-token.${expiresAt}`,
+          isAdmin: false,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          'Set-Cookie': 'refreshToken=user-refresh-token; HttpOnly; Path=/; SameSite=Lax',
+        },
+      },
+    );
   }),
 ];

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,9 +1,4 @@
-let alreadyStarted = false;
-
 export async function initMsw() {
-  if (alreadyStarted) return;
-  alreadyStarted = true;
-
   if (typeof window !== 'undefined') {
     const { worker } = await import('./browser');
     await worker.start({

--- a/src/mocks/utils/check-access-token.ts
+++ b/src/mocks/utils/check-access-token.ts
@@ -1,0 +1,43 @@
+interface MswTokenDataType {
+  type: string;
+  expiresAt: number;
+  isAdmin: boolean;
+}
+
+export function checkAccessToken(authHeader: string | null): {
+  isValid: boolean;
+  isExpired: boolean;
+  tokenData?: MswTokenDataType;
+} {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { isValid: false, isExpired: false };
+  }
+
+  const token = authHeader.replace('Bearer ', '');
+
+  const tokenParts = token.split('.');
+
+  if (tokenParts.length !== 2) {
+    return { isValid: false, isExpired: false };
+  }
+
+  const [tokenType, expiresAtStr] = tokenParts;
+  const expiresAt = parseInt(expiresAtStr);
+
+  if (isNaN(expiresAt)) {
+    return { isValid: false, isExpired: false };
+  }
+
+  const now = Date.now();
+  const isExpired = now > expiresAt;
+
+  return {
+    isValid: true,
+    isExpired,
+    tokenData: {
+      type: tokenType,
+      expiresAt,
+      isAdmin: tokenType.includes('admin'),
+    },
+  };
+}

--- a/tests/auth/auth.spec.ts
+++ b/tests/auth/auth.spec.ts
@@ -1,0 +1,286 @@
+import { test, expect } from '@playwright/test';
+
+import { isLoggedIn, expectAlertMessage, performLogin, performLogout } from '../utils/test-helpers';
+
+test.describe('인증 기능 E2E 테스트', () => {
+  test('1. 로그인 안되어있는 상태에는 헤더에 로그인 버튼이 떠있고, 로그인 버튼을 누르면 로그인 페이지로 이동한다', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    expect(await isLoggedIn(page)).toBe(false);
+
+    const loginButton = page.locator('header a[href="/login"]');
+    await expect(loginButton).toBeVisible();
+
+    await loginButton.click();
+
+    await expect(page).toHaveURL('/login');
+    await expect(page.locator('h2:has-text("EduMate")')).toBeVisible();
+  });
+
+  test('2. 로그인할 때 이메일 형식이 안맞거나, 교직용 이메일이 아닐때, 비밀번호 형식이 맞지 않을때 로그인 버튼을 누르면 error.message가 빨갛게 나오고 api요청이 안간다', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+
+    const apiRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/api/v1/auth/login')) {
+        apiRequests.push(request.url());
+      }
+    });
+
+    await page.fill('input[placeholder="이메일"]', 'invalid-email');
+    await page.fill('input[placeholder="비밀번호"]', 'ab12341234!');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    const emailFormatError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '이메일 형식이 유효하지 않습니다.' });
+    await expect(emailFormatError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input[placeholder="이메일"]', 'test@daum.com');
+    await page.fill('input[placeholder="비밀번호"]', 'ab12341234!');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    const teacherEmailError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '교직 이메일이 아닙니다.' });
+    await expect(teacherEmailError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input[placeholder="이메일"]', 'test@edukit.co.kr');
+    await page.fill('input[placeholder="비밀번호"]', '123');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    const passwordLengthError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '비밀번호는 최소 8자 이상이어야 합니다.' });
+    await expect(passwordLengthError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input[placeholder="이메일"]', 'test@edukit.co.kr');
+    await page.fill('input[placeholder="비밀번호"]', 'aaaaaaaa');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    const passwordComplexityError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '영문/숫자/특수문자 중 2가지 이상 포함해야 합니다.' });
+    await expect(passwordComplexityError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input[placeholder="이메일"]', 'test@edukit.co.kr');
+    await page.fill('input[placeholder="비밀번호"]', 'ab12312312333');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    const passwordSamewordError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '동일 문자를 3번 연속으로 사용할 수 없습니다.' });
+    await expect(passwordSamewordError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+  });
+
+  test('3. 로그인할 때 이메일이 없거나 비밀번호가 틀릴때 error.message가 빨갛게 나온다', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+
+    await page.fill('input[placeholder="이메일"]', 'test@edukit.co.kr');
+    await page.fill('input[placeholder="비밀번호"]', 'abcd1234');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    await page.waitForSelector('p.text-red-500', { timeout: 5000 });
+    const passwordError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '비밀번호가 일치하지 않습니다.' });
+    await expect(passwordError).toBeVisible();
+
+    await page.fill('input[placeholder="이메일"]', '123@edukit.co.kr');
+    await page.fill('input[placeholder="비밀번호"]', 'abcd1234');
+    await page.click('button[type="submit"]:has-text("로그인")');
+
+    await page.waitForSelector('p.text-red-500', { timeout: 5000 });
+    const notFoundError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '존재하지 않는 회원입니다. 회원가입을 진행해주세요.' });
+    await expect(notFoundError).toBeVisible();
+  });
+
+  test('4. 로그인 성공하면 랜딩페이지로 이동하고, 헤더에 프로필 이미지가 나온다', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+
+    await expect(page).toHaveURL('/');
+
+    await expect(page.locator('header img[alt="profile image"]')).toBeVisible();
+
+    const loginButton = page.locator('header a[href="/login"]');
+    await expect(loginButton).not.toBeVisible();
+  });
+
+  test('5. 회원가입 페이지에서 유효성 검사 실패 시 error.message가 빨갛게 나오고 api요청이 안간다', async ({
+    page,
+  }) => {
+    await page.goto('/signup');
+
+    const apiRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/api/v1/auth/signup')) {
+        apiRequests.push(request.url());
+      }
+    });
+
+    await page.fill('input#email', 'test');
+    await page.fill('input#password', 'ab12341234!');
+    await page.fill('input#confirmPassword', 'ab12341234!');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    const emailFormatError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '이메일 형식이 유효하지 않습니다.' });
+    await expect(emailFormatError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input#email', 'test@daum.net');
+    await page.fill('input#password', 'ab12341234!');
+    await page.fill('input#confirmPassword', 'ab12341234!');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    const teacherEmailError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '교직 이메일이 아닙니다.' });
+    await expect(teacherEmailError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input#email', 'test@edukit.co.kr');
+    await page.fill('input#password', '123');
+    await page.fill('input#confirmPassword', '123');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    const passwordLengthError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '비밀번호는 최소 8자 이상이어야 합니다.' });
+    await expect(passwordLengthError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input#email', 'test@edukit.co.kr');
+    await page.fill('input#password', 'ab12341234');
+    await page.fill('input#confirmPassword', 'ab12341234!');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    const passwordMismatchError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '비밀번호가 일치하지 않습니다.' });
+    await expect(passwordMismatchError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.reload();
+
+    await page.fill('input#email', 'test@edukit.co.kr');
+    await page.fill('input#password', 'ab12341234!');
+    await page.fill('input#confirmPassword', 'ab12341234!');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    const subjectError = page
+      .locator('p.text-red-500')
+      .filter({ hasText: '교과목을 입력해주세요.' });
+    await expect(subjectError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+
+    await page.click('button:has-text("담당 교과목 선택")');
+    await page.waitForSelector('input[type="text"]', { state: 'visible' });
+    await page.fill('input[type="text"]', '수학');
+    await page.press('input[type="text"]', 'Enter');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    const schoolError = page.locator('p.text-red-500').filter({ hasText: '학교를 선택해주세요.' });
+    await expect(schoolError).toBeVisible();
+    expect(apiRequests.length).toBe(0);
+  });
+
+  test('6. 회원가입할때 중복된 이메일이 있으면 alert메세지가 나온다', async ({ page }) => {
+    await page.goto('/signup');
+
+    await page.fill('input#email', 'test123@edukit.co.kr');
+    await page.fill('input#password', 'ab12341234!');
+    await page.fill('input#confirmPassword', 'ab12341234!');
+    await page.click('button:has-text("담당 교과목 선택")');
+    await page.waitForSelector('input[type="text"]', { state: 'visible' });
+    await page.fill('input[type="text"]', '수학');
+    await page.press('input[type="text"]', 'Enter');
+    await page.click('button:has-text("고등학교")');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    await page.waitForTimeout(2000);
+    await expectAlertMessage(page, '중복된 이메일입니다.');
+  });
+
+  test('7. 회원가입 성공하면 SuccessSignup 컴포넌트가 나온다', async ({ page }) => {
+    await page.goto('/signup');
+
+    await page.fill('input#email', 'test123231@edukit.co.kr');
+    await page.fill('input#password', 'ab12341234!');
+    await page.fill('input#confirmPassword', 'ab12341234!');
+    await page.click('button:has-text("담당 교과목 선택")');
+    await page.waitForSelector('input[type="text"]', { state: 'visible' });
+    await page.fill('input[type="text"]', '수학');
+    await page.press('input[type="text"]', 'Enter');
+    await page.click('button:has-text("고등학교")');
+    await page.click('button[type="submit"]:has-text("가입하기")');
+
+    await expect(page.locator('h2:has-text("가입 완료")')).toBeVisible();
+    await expect(page.locator('text=가입하신 이메일로 인증 메일을 보냈습니다.')).toBeVisible();
+  });
+
+  test('8. verify-email 페이지에 id === "test@naver.com" && code === "abc" 일때 이메일 인증이 완료되었습니다! 가 나온다', async ({
+    page,
+  }) => {
+    await page.goto('/verify-email?id=test@naver.com&code=abc');
+    await expect(page.locator('h1:has-text("이메일 인증이 완료되었습니다!")')).toBeVisible();
+    await expect(page.locator('text=원래 있던 브라우저로 돌아가주세요.')).toBeVisible();
+  });
+
+  test('9. verify-email 페이지에 id === "test@naver.com" && code === "abc" 아닐때 이메일 인증에 실패했습니다. 가 나온다', async ({
+    page,
+  }) => {
+    await page.goto('/verify-email?id=test@naver.com&code=wrong');
+    await expect(page.locator('h1:has-text("이메일 인증에 실패했습니다.")')).toBeVisible();
+    await expect(page.locator('text=이미 만료된 인증 코드입니다.')).toBeVisible();
+
+    await page.goto('/verify-email?id=wrong@email.com&code=abc');
+    await expect(page.locator('h1:has-text("이메일 인증에 실패했습니다.")')).toBeVisible();
+    await expect(page.locator('text=이미 만료된 인증 코드입니다.')).toBeVisible();
+  });
+
+  test('10. 로그인상태에서 로그아웃 버튼을 누르면 헤더의 프로필 이미지에서 로그인 버튼으로 바뀐다', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+
+    await expect(page.locator('header img[alt="profile image"]')).toBeVisible();
+    expect(await isLoggedIn(page)).toBe(true);
+
+    await performLogout(page);
+
+    const loginButton = page.locator('header a[href="/login"]');
+    await expect(loginButton).toBeVisible();
+    expect(await isLoggedIn(page)).toBe(false);
+  });
+});

--- a/tests/auth/auth.spec.ts
+++ b/tests/auth/auth.spec.ts
@@ -297,7 +297,9 @@ test.describe('인증 기능 E2E 테스트', () => {
     expect(await isLoggedIn(page)).toBe(true);
   });
 
-  test('12. accessToken 만료 시 새로고침 없이도 프로필 기능이 정상 동작한다.', async ({ page }) => {
+  test('12. accessToken 만료 후 api 요청이 발생할 때, reissue를 요청하고 새로운 accessToken을 받아와 다시 요청하는 interceptor 로직이 정상적으로 동작한다.', async ({
+    page,
+  }) => {
     await performLogin(page, 'test@edukit.co.kr', 'password1234!');
     await page.waitForTimeout(1000);
     expect(await isLoggedIn(page)).toBe(true);

--- a/tests/landing-page.spec.ts
+++ b/tests/landing-page.spec.ts
@@ -43,7 +43,6 @@ test.describe('EduMate 랜딩 페이지', () => {
     const startTime = Date.now();
 
     await page.goto('/');
-    await page.waitForLoadState('domcontentloaded');
 
     const loadTime = Date.now() - startTime;
     expect(loadTime).toBeLessThan(5000);

--- a/tests/notice/notice.spec.ts
+++ b/tests/notice/notice.spec.ts
@@ -3,7 +3,6 @@ import { test, expect } from '@playwright/test';
 test.describe('공지사항 기본 기능 E2E 테스트', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/notice');
-    await page.waitForLoadState('domcontentloaded');
   });
 
   test('1. 공지사항 목록이 잘 나온다.', async ({ page }) => {
@@ -31,19 +30,16 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
     page,
   }) => {
     await page.goto('/notice?page=10');
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page.locator('text=등록된 공지사항이 없습니다.')).toBeVisible();
 
     await page.goto('/notice/1231231');
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page.locator('text=등록된 공지사항이 없습니다.')).toBeVisible();
   });
 
   test('3. 공지 태그 필터링이 올바르게 작동한다', async ({ page }) => {
     await page.click('a[href="/notice?categoryId=2"]');
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL('/notice?categoryId=2');
 
@@ -63,7 +59,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
 
   test('4. 이벤트 태그 필터링이 올바르게 작동한다', async ({ page }) => {
     await page.click('a[href="/notice?categoryId=3"]');
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL('/notice?categoryId=3');
 
@@ -86,7 +81,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
 
     if (await page2Button.isVisible()) {
       await page2Button.click();
-      await page.waitForLoadState('domcontentloaded');
 
       await expect(page).toHaveURL('/notice?page=2');
 
@@ -99,13 +93,11 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
 
   test('6. 카테고리와 페이지네이션이 함께 정상적으로 동작한다', async ({ page }) => {
     await page.click('a[href="/notice?categoryId=2"]');
-    await page.waitForLoadState('domcontentloaded');
 
     const page2Button = page.locator('a[href*="categoryId=2"][href*="page=2"]');
 
     if (await page2Button.isVisible()) {
       await page2Button.click();
-      await page.waitForLoadState('domcontentloaded');
 
       await expect(page).toHaveURL('/notice?categoryId=2&page=2');
 
@@ -128,7 +120,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
     const noticeHref = await firstNotice.getAttribute('href');
 
     await firstNotice.click();
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL(noticeHref!);
 
@@ -157,7 +148,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
     await expect(backButton).toBeVisible();
 
     await backButton.click();
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL('/notice');
     await expect(page.locator('h2:has-text("공지사항")')).toBeVisible();
@@ -165,7 +155,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
 
   test('8. URL로 직접 접근 시 올바른 데이터가 표시된다', async ({ page }) => {
     await page.goto('/notice?categoryId=2&page=2');
-    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL('/notice?categoryId=2&page=2');
 
@@ -186,9 +175,9 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
 
   test('9. 브라우저 새로고침 시 상태가 유지된다', async ({ page }) => {
     await page.goto('/notice?categoryId=3&page=1');
-    await page.waitForLoadState('domcontentloaded');
 
     await page.reload();
+    await page.waitForTimeout(1000);
 
     await expect(page).toHaveURL('/notice?categoryId=3&page=1');
 
@@ -209,7 +198,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
 
   test('10. 페이지네이션 경계값에서 <, > 버튼 상태가 올바르다', async ({ page }) => {
     await page.goto('/notice');
-    await page.waitForLoadState('domcontentloaded');
 
     const firstPagePrevButton = page.locator('span.text-slate-300:has-text("<")');
     await expect(firstPagePrevButton).toBeVisible();
@@ -233,7 +221,6 @@ test.describe('공지사항 기본 기능 E2E 테스트', () => {
         }
 
         await nextButton.click();
-        await page.waitForLoadState('domcontentloaded');
 
         iterations++;
 

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -4,8 +4,21 @@ import { expect, type Page } from '@playwright/test';
 export async function isLoggedIn(page: Page): Promise<boolean> {
   try {
     const profileImage = page.locator('header img[alt="profile image"]');
-    const isVisible = await profileImage.isVisible();
-    return isVisible;
+    const isProfileVisible = await profileImage.isVisible();
+
+    if (!isProfileVisible) {
+      return false;
+    }
+
+    await profileImage.click();
+    await page.waitForTimeout(500);
+
+    const logoutButton = page.locator('button:has-text("로그아웃")');
+    const hasLogoutButton = await logoutButton.isVisible();
+
+    await page.click('body');
+
+    return hasLogoutButton;
   } catch {
     return false;
   }

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -1,0 +1,37 @@
+import { expect, type Page } from '@playwright/test';
+
+// 로그인 여부를 확인하는 헬퍼 함수
+export async function isLoggedIn(page: Page): Promise<boolean> {
+  try {
+    const profileImage = page.locator('header img[alt="profile image"]');
+    const isVisible = await profileImage.isVisible();
+    return isVisible;
+  } catch {
+    return false;
+  }
+}
+
+// 서버 에러 (alert) 메시지 확인 헬퍼 함수
+export async function expectAlertMessage(page: Page, expectedMessage: string) {
+  page.on('dialog', async (dialog) => {
+    expect(dialog.message()).toBe(expectedMessage);
+    await dialog.accept();
+  });
+}
+
+// 로그인을 수행하는 헬퍼 함수
+export async function performLogin(page: Page, email: string, password: string) {
+  await page.goto('/login');
+
+  await page.fill('input[placeholder="이메일"]', email);
+  await page.fill('input[placeholder="비밀번호"]', password);
+
+  await page.click('button[type="submit"]:has-text("로그인")');
+}
+
+// 로그아웃을 수행하는 헬퍼 함수
+export async function performLogout(page: Page) {
+  await page.click('header img[alt="profile image"]');
+
+  await page.click('button:has-text("로그아웃")');
+}


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-259]

## 🌱 주요 변경 사항

1. test 환경에서의 env 파일 주입을 위한 playwright.config.ts 파일에 해당 코드 주입
2. msw 환경에서 auth 코드 관련 에러 상황 대응을 위한 에러 케이스 추가
3. 페이지네이션 테스트 코드 리팩토링('>' 클릭하는 경우로 수정)
4. test 환경에서 alert창이 올바르게 나오는지, 로그인 여부 체크, 로그인, 로그아웃을 공통으로 쉽게 하기 위한 helper 함수 구현
5. msw 환경에서 새로고침 시 워커가 등록되기 전에 api 를 요청하는 이슈가 발생하여 isReady라는 상태값을 추가하여 mocking enabled가 끝날 때 children을 렌더링하는 로직 추가
6. Msw환경에서 accessToken을 파싱하는 util함수 추가
7. msw 환경에서 로그인/회원가입/reissue api에 각각 accessToken, refreshToken을 실제 프로덕션 환경과 동일하게 설정
8. msw get-profile 함수에 accessToken 을 파싱하는 로직을 적용하여, accessToken이 만료되었을 때 401에러를 내려주는 로직 추가
9. 랜딩페이지, 공지사항 테스트 코드에 의미 없는 waitForLoadState로직 삭제
10. auth 서비스 e2e 테스트 코드 작성 및 테스트 진행

## auth 테스트 케이스
1. 로그인 안되어있는 상태에는 헤더에 로그인 버튼이 떠있고, 로그인 버튼을 누르면 로그인 페이지로 이동한다.
2. 로그인할 때 이메일 형식이 안맞거나, 교직용 이메일이 아닐때, 비밀번호 형식이 맞지 않을때 로그인 버튼을 누르면 error.message가 빨갛게 나오고 api요청이 안간다.
3. 로그인할 때 이메일이 없거나 비밀번호가 틀릴때error.message가 빨갛게 나온다.
4. 로그인 성공하면 랜딩페이지로 이동하고, 헤더에 프로필 이미지가 나온다.
5. 회원가입 페이지에서 이메일 형식이 안맞거나, 교직용 이메일이 아닐때, 비밀번호 형식이 맞지 않을때, 비밀번호 확인이 비밀번호랑 다를때, 담당 교과목을 선택하지 않을때, 중/고등학교를 선택하지 않을때 error.message가 빨갛게 나오고 api요청이 안간다.
11. 회원가입할때 중복된 이메일이 있으면 alert메세지가 나온다.
12. 회원가입 성공하면 SuccessSignup 컴포넌트가 나온다.
13. verify-email 페이지에 id === 'test@naver.com' && code === 'abc’ 일때 이메일 인증이 완료되었습니다! 가 나온다.
14. verify-email 페이지에 id === 'test@naver.com' && code === 'abc’ 아닐때 이메일 인증에 실패했습니다. 가 나온다.
15. 로그인상태에서 로그아웃 버튼을 누르면 헤더의 프로필 이미지에서 로그인 버튼으로 바뀐다.
16. 페이지 새로고침 후에도 로그인 상태가 유지된다.
17. accessToken 만료 후 api 요청이 발생할 때, reissue를 요청하고 새로운 accessToken을 받아와 다시 요청하는 interceptor 로직이 정상적으로 동작한다.

## 📸 스크린샷 (선택)
<img width="1278" height="793" alt="스크린샷 2025-07-16 오후 4 17 30" src="https://github.com/user-attachments/assets/86e840ee-1698-4668-a009-6d7ad553e42a" />



[EDMT-259]: https://bbangbbangz.atlassian.net/browse/EDMT-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 기능에 대한 엔드 투 엔드(E2E) 테스트가 추가되었습니다.
  * 인증 및 알림 메시지 처리를 위한 테스트 헬퍼 유틸리티가 도입되었습니다.

* **버그 수정**
  * 이메일 인증 시 URL 파라미터가 올바르게 디코딩되도록 개선되었습니다.
  * 로그인 및 회원가입 시 오류 메시지와 조건 분기가 보다 명확하게 처리됩니다.
  * 사용자 프로필 API 호출 시 토큰 유효성 및 만료 상태 검증이 추가되었습니다.
  * 토큰 재발급 시 쿠키에서 리프레시 토큰을 정확히 확인하도록 개선되었습니다.

* **테스트**
  * 인증 및 공지사항 페이지네이션 관련 테스트가 강화되었습니다.
  * 테스트 환경에서 필요한 환경변수가 명확히 설정됩니다.

* **기타**
  * MSW(Mock Service Worker) 초기화 및 사용 로직이 개발 환경과 API 모킹 활성화 여부에 따라 조건부로 변경되었습니다.
  * 테스트 및 개발 환경에서의 웹 서버 환경변수 설정이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->