### PR TITLE
[EDMT-261] 나의 학생 관리 기능 테스트 코드 작성 및 테스트 진행

### DIFF
--- a/src/components/modal/delete-confirm-modal.tsx
+++ b/src/components/modal/delete-confirm-modal.tsx
@@ -48,6 +48,7 @@ export default function DeleteConfirmModal({
               취소
             </button>
             <button
+              data-testid="modal-remove-button"
               onClick={onDelete}
               className="rounded-md bg-red-700 px-6 py-2 font-bold text-white hover:bg-red-600"
             >

--- a/src/components/record/record-detail-add.tsx
+++ b/src/components/record/record-detail-add.tsx
@@ -1,7 +1,9 @@
 import { useRef } from 'react';
 
 import { Input } from '@/components/input/input';
+import { Textarea } from '@/components/textarea/textarea';
 import { useCreateRecordDetail } from '@/hooks/api/student-manage/use-create-record-detail';
+import { useAutoResizeTextarea } from '@/hooks/use-auto-resize-textarea';
 import type { RecordType } from '@/types/api/student-record';
 import { calculateByte } from '@/util/calculate-byte';
 
@@ -15,43 +17,55 @@ export default function RecordDetailAdd({ recordType, onCancel }: RecordDetailAd
 
   const studentNumberRef = useRef<HTMLInputElement>(null);
   const studentNameRef = useRef<HTMLInputElement>(null);
-  const descriptionRef = useRef<HTMLInputElement>(null);
+  const { textareaRef, resizeTextarea } = useAutoResizeTextarea('');
 
   const handleCreate = () => {
     const studentRecord = {
       studentNumber: studentNumberRef.current?.value || '',
       studentName: studentNameRef.current?.value || '',
-      description: descriptionRef.current?.value || '',
-      byteCount: calculateByte(descriptionRef.current?.value || ''),
+      description: textareaRef.current?.value || '',
+      byteCount: calculateByte(textareaRef.current?.value || ''),
     };
 
     createRecordDetail({ recordType, studentRecord, semester: '2025-1' }, { onSuccess: onCancel });
   };
 
   return (
-    <tr className="relative">
-      <td className="py-2 pl-5">
-        <Input ref={studentNumberRef} className="w-full p-1" />
+    <tr>
+      <td className="py-2 pl-5 align-middle">
+        <Input data-testid="student-number-input" ref={studentNumberRef} className="w-full p-1" />
       </td>
-      <td className="py-2 pl-5">
-        <Input ref={studentNameRef} className="w-full p-1" />
+      <td className="py-2 pl-5 align-middle">
+        <Input data-testid="student-name-input" ref={studentNameRef} className="w-full p-1" />
       </td>
-      <td className="py-2 pl-5">
-        <Input ref={descriptionRef} className="w-full p-1" />
-      </td>
-      <td className="absolute right-0 top-14 flex gap-2">
-        <button
-          className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
-          onClick={onCancel}
-        >
-          취소하기
-        </button>
-        <button
-          className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
-          onClick={handleCreate}
-        >
-          추가하기
-        </button>
+      <td className="py-2 pl-5 align-middle">
+        <div className="space-y-3">
+          <Textarea
+            data-testid="description-textarea"
+            ref={textareaRef}
+            className="min-h-0 w-full resize-none p-1 text-sm"
+            style={{
+              lineHeight: 'inherit',
+              fontSize: 'inherit',
+              overflow: 'hidden',
+            }}
+            onInput={resizeTextarea}
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
+              onClick={onCancel}
+            >
+              취소하기
+            </button>
+            <button
+              className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
+              onClick={handleCreate}
+            >
+              추가하기
+            </button>
+          </div>
+        </div>
       </td>
     </tr>
   );

--- a/src/components/record/record-detail-edit.tsx
+++ b/src/components/record/record-detail-edit.tsx
@@ -61,17 +61,24 @@ export default function RecordDetailEdit({ record, recordType, onView }: RecordD
       <tr>
         <td className="py-2 pl-5 align-middle">
           <Input
+            data-testid="student-number-input"
             defaultValue={record.studentNumber}
             ref={studentNumberRef}
             className="w-full p-1"
           />
         </td>
         <td className="py-2 pl-5 align-middle">
-          <Input defaultValue={record.studentName} ref={studentNameRef} className="w-full p-1" />
+          <Input
+            data-testid="student-name-input"
+            defaultValue={record.studentName}
+            ref={studentNameRef}
+            className="w-full p-1"
+          />
         </td>
         <td className="py-2 pl-5 align-middle">
           <div className="space-y-3">
             <Textarea
+              data-testid="description-textarea"
               ref={textareaRef}
               defaultValue={record.description}
               className="min-h-0 w-full resize-none p-1 text-sm"

--- a/src/components/record/students-add-button.tsx
+++ b/src/components/record/students-add-button.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 
 import ExcelUploadModal from '@/components/modal/excel-upload-modal';
-import { useAuth } from '@/contexts/auth/use-auth';
 import { useGetRecords } from '@/hooks/api/student-manage/use-get-records';
 import type { RecordType } from '@/types/api/student-record';
 import { downloadExcel } from '@/util/download-excel';
@@ -11,15 +10,13 @@ import { downloadExcel } from '@/util/download-excel';
 export default function StudentAddButton({ recordType }: { recordType: RecordType }) {
   const [excelModalOpen, setExcelModalOpen] = useState(false);
 
-  const { data } = useGetRecords(recordType);
+  const { data, isPending, isError } = useGetRecords(recordType);
 
-  const { accessToken } = useAuth();
-
-  const hasStudents = data && data.students.length > 0;
-
-  if (accessToken === null) {
+  if (isPending || isError) {
     return null;
   }
+
+  const hasStudents = data && data.students.length > 0;
 
   const handleDownloadExcel = () => {
     if (hasStudents) {

--- a/src/constants/record-data.ts
+++ b/src/constants/record-data.ts
@@ -1,29 +1,37 @@
-import type { RecordType, StudentRecord } from '@/types/api/student-record';
+import type { RecordType, StudentsResponse } from '@/types/api/student-record';
 
-export const RECORD_DATA: Record<RecordType, StudentRecord[]> = {
-  career: Array.from({ length: 100 }, (_, i) => ({
-    recordDetailId: `career-${i + 1}`,
-    studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
-    studentName: `학생${i + 1}`,
-    description: '진로 기록 예시: 책임감 있고 성실한 학생입니다.',
-  })),
-  subject: Array.from({ length: 40 }, (_, i) => ({
-    recordDetailId: `subject-${i + 1}`,
-    studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
-    studentName: `학생${i + 1}`,
-    description: '과목별 성취 기록 예시: 도전적이고 자기주도적 학습 태도를 보입니다.',
-  })),
-  behavior: [],
-  free: Array.from({ length: 5 }, (_, i) => ({
-    recordDetailId: `free-${i + 1}`,
-    studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
-    studentName: `학생${i + 1}`,
-    description: '자유기록 예시: 창의적이고 다양한 활동에 참여합니다.',
-  })),
-  club: Array.from({ length: 20 }, (_, i) => ({
-    recordDetailId: `club-${i + 1}`,
-    studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
-    studentName: `학생${i + 1}`,
-    description: '동아리 활동 예시: 열정적으로 참여하고 리더십을 발휘합니다.',
-  })),
+export const RECORD_DATA: Record<RecordType, StudentsResponse> = {
+  career: {
+    students: Array.from({ length: 100 }, (_, i) => ({
+      recordDetailId: `career-${i + 1}`,
+      studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
+      studentName: `학생${i + 1}`,
+      description: '진로 기록 예시: 책임감 있고 성실한 학생입니다.',
+    })),
+  },
+  subject: {
+    students: Array.from({ length: 40 }, (_, i) => ({
+      recordDetailId: `subject-${i + 1}`,
+      studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
+      studentName: `학생${i + 1}`,
+      description: '과목별 성취 기록 예시: 도전적이고 자기주도적 학습 태도를 보입니다.',
+    })),
+  },
+  behavior: { students: [] },
+  free: {
+    students: Array.from({ length: 5 }, (_, i) => ({
+      recordDetailId: `free-${i + 1}`,
+      studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
+      studentName: `학생${i + 1}`,
+      description: '자유기록 예시: 창의적이고 다양한 활동에 참여합니다.',
+    })),
+  },
+  club: {
+    students: Array.from({ length: 20 }, (_, i) => ({
+      recordDetailId: `club-${i + 1}`,
+      studentNumber: `21-${Math.floor(Math.random() * 100000000)}`,
+      studentName: `학생${i + 1}`,
+      description: '동아리 활동 예시: 열정적으로 참여하고 리더십을 발휘합니다.',
+    })),
+  },
 };

--- a/src/mocks/handlers/student-manage/get-records.ts
+++ b/src/mocks/handlers/student-manage/get-records.ts
@@ -1,12 +1,49 @@
 import { http, HttpResponse } from 'msw';
 
 import { RECORD_DATA } from '@/constants/record-data';
+import { checkAccessToken } from '@/mocks/utils/check-access-token';
 import type { RecordType } from '@/types/api/student-record';
 
 export const getRecords = [
   http.get<never, { recordType: RecordType }>(
     '/api/v1/student-records/:recordType',
-    ({ params }) => {
+    ({ params, request }) => {
+      const authHeader = request.headers.get('Authorization');
+
+      const validation = checkAccessToken(authHeader);
+
+      if (!validation.isValid) {
+        return HttpResponse.json(
+          {
+            status: 401,
+            code: 'EDMT-4010101',
+            message: '유효하지 않은 토큰입니다.',
+          },
+          { status: 401 },
+        );
+      }
+
+      if (validation.isExpired) {
+        return HttpResponse.json(
+          {
+            status: 401,
+            code: 'EDMT-4010102',
+            message: '만료된 토큰입니다.',
+          },
+          { status: 401 },
+        );
+      }
+
+      if (validation.isNotVerified) {
+        return HttpResponse.json(
+          {
+            status: 403,
+            code: 'EDMT-4030101',
+            message: '권한이 부족한 사용자입니다.',
+          },
+          { status: 403 },
+        );
+      }
       const { recordType } = params;
 
       const records = RECORD_DATA[recordType];

--- a/src/mocks/utils/check-access-token.ts
+++ b/src/mocks/utils/check-access-token.ts
@@ -11,22 +11,14 @@ export function checkAccessToken(authHeader: string | null): {
   tokenData?: MswTokenDataType;
 } {
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return { isValid: false, isNotVerified: true, isExpired: false };
+    return { isValid: false, isNotVerified: false, isExpired: false };
   }
 
-  const token = authHeader.replace('Bearer ', '');
-
-  const tokenParts = token.split('.');
-
-  if (tokenParts.length !== 2) {
-    return { isValid: false, isNotVerified: true, isExpired: false };
-  }
-
-  const [tokenType, expiresAtStr] = tokenParts;
+  const [tokenType, expiresAtStr] = authHeader.replace('Bearer ', '').split('.');
   const expiresAt = parseInt(expiresAtStr);
 
   if (isNaN(expiresAt)) {
-    return { isValid: false, isNotVerified: true, isExpired: false };
+    return { isValid: false, isNotVerified: false, isExpired: false };
   }
 
   const now = Date.now();

--- a/tests/student-manage/student-manage.spec.ts
+++ b/tests/student-manage/student-manage.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test';
+
+import {
+  performLogin,
+  performLogout,
+  waitForApiResponse,
+  expectAlertMessage,
+} from '../utils/test-helpers';
+
+test.describe('학생 관리 페이지 E2E 테스트', () => {
+  test('1. 로그인이 안되어 있는 상태에서 사이드바의 나의 학생 관리 하위 항목인 세부능력 및 특기사항을 클릭해서 들어가면 로그인이 필요합니다 라는 텍스트가 나오고, 학생 추가/엑셀로 내보내기 버튼이 보이지 않고, 로그인 버튼을 누르면 로그인 페이지로 이동한다.', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.click('a[href="/manage-subject"]');
+    await expect(page.locator('text=로그인이 필요합니다')).toBeVisible();
+
+    await expect(page.locator('button:has-text("학생 추가")')).not.toBeVisible();
+    await expect(page.locator('td:has-text("+ 추가하기")')).not.toBeVisible();
+    await expect(page.locator('button:has-text("엑셀로 내보내기")')).not.toBeVisible();
+
+    await page.click('a[href="/login"]:has-text("로그인")');
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('2. 이메일 인증하지 않은 유저가 로그인 하고 사이드바의 나의 학생 관리 하위 항목인 행동 특성 및 종합의견을 클릭해서 들어가면 이메일을 인증해주세요 라는 텍스트가 나오고, 학생 추가/엑셀로 내보내기 버튼이 보이지 않고, 로그아웃을 하고 다시 들어가면 로그인이 필요합니다 라는 텍스트가 나온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'ab12345678');
+    await page.goto('/');
+    await page.click('a[href="/manage-behavior"]');
+
+    await expect(page.locator('text=이메일 인증 후 서비스 이용이 가능합니다.')).toBeVisible();
+
+    await expect(page.locator('button:has-text("학생 추가")')).not.toBeVisible();
+    await expect(page.locator('td:has-text("+ 추가하기")')).not.toBeVisible();
+    await expect(page.locator('button:has-text("엑셀로 내보내기")')).not.toBeVisible();
+
+    await performLogout(page);
+    await page.goto('/manage-behavior');
+    await expect(page.locator('text=로그인이 필요합니다')).toBeVisible();
+  });
+
+  test('3. 로그인 하고 사이드바의 나의 학생 관리 하위 항목인 행동 특성 및 종합의견을 클릭해서 들어가면 엑셀로 내보내기 버튼이 disabled 상태이고, 학생 데이터가 0개이며 추가하기 버튼만 나온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.goto('/');
+    await page.click('a[href="/manage-behavior"]');
+
+    await expect(page.locator('button:has-text("엑셀로 내보내기")')).toBeDisabled();
+    await expect(page.locator('table tbody tr')).toHaveCount(1);
+    await expect(page.locator('td:has-text("+ 추가하기")')).toBeVisible();
+  });
+
+  test('4. 로그인하고 manage-behavior 링크로 들어와서 학생 등록하고 생활기록부 관리하기 버튼을 클릭해서 템플릿을 다운로드 하고, 파일 업로드를 클릭해서 해당 템플릿 excel 파일을 올리면 이름 목록이 잘 나오고, 생성하기버튼을 누르면 api 응답이 200으로 잘 내려온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.goto('/manage-behavior');
+
+    await page.click('button:has-text("학생 추가")');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.click('button:has-text("템플릿 다운로드")');
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(downloadPath);
+
+    await expect(page.locator('text=홍길동')).toBeVisible();
+    await expect(page.locator('text=김철수')).toBeVisible();
+    await expect(page.locator('text=이영희')).toBeVisible();
+    await expect(page.locator('text=업로드된 학생 목록 (3명)')).toBeVisible();
+
+    const apiResponsePromise = waitForApiResponse(
+      page,
+      '/api/v1/student-records/behavior/students/batch',
+      'POST',
+    );
+
+    await page.click('button:has-text("3명 생성하기")');
+    await apiResponsePromise;
+  });
+
+  test('5. 엑셀 업로드 시 잘못된 파일 형식을 업로드하면, 엑셀 파일을 처리하는 중 오류가 발생했습니다. 라는 alert 창이 나온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.goto('/manage-behavior');
+
+    await page.click('button:has-text("학생 추가")');
+
+    await expectAlertMessage(page, '엑셀 파일을 처리하는 중 오류가 발생했습니다.');
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'test.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('invalid file content'),
+    });
+  });
+
+  test('6. 추가하기 버튼을 눌러서 학번, 이름, 내용을 채워넣고 추가하기 버튼을 누르면 api 응답이 200으로 내려온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.goto('/manage-behavior');
+
+    await page.click('td:has-text("+ 추가하기")');
+
+    await page.fill('input[data-testid="student-number-input"]', '2024001');
+    await page.fill('input[data-testid="student-name-input"]', '테스트학생');
+    await page.fill(
+      'textarea[data-testid="description-textarea"]',
+      '성실하고 적극적인 학생입니다.',
+    );
+
+    const apiResponsePromise = waitForApiResponse(page, '/api/v1/student-records/behavior', 'POST');
+
+    await page.click('button:has-text("추가하기")');
+    await apiResponsePromise;
+  });
+
+  test('7. 로그인하고, 세부 능력 및 특기사항에서 table 맨 위의 row를 클릭해서 이름을 수정하고 수정하기 버튼을 누르면 api 응답이 200으로 내려온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.click('a[href="/manage-subject"]');
+
+    await page.locator('table tbody tr').first().click();
+
+    const nameInput = page.locator('input[data-testid="student-name-input"]');
+    await nameInput.clear();
+    await nameInput.fill('수정된이름');
+
+    const apiResponsePromise = waitForApiResponse(page, '/api/v1/student-records/subject', 'PATCH');
+
+    await page.click('button:has-text("수정하기")');
+    await apiResponsePromise;
+  });
+
+  test('8. 로그인하고, 세부 능력 및 특기사항에서 table 맨 위의 row를 클릭해서 삭제하기 버튼을 누르면 api응답이 200으로 내려온다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.click('a[href="/manage-subject"]');
+
+    await page.locator('table tbody tr').first().click();
+
+    const apiResponsePromise = waitForApiResponse(
+      page,
+      '/api/v1/student-records/subject',
+      'DELETE',
+    );
+
+    await page.click('button:has-text("삭제하기")');
+    await expect(page.locator('text=정말 삭제하시겠습니까?')).toBeVisible();
+    await page.click('button[data-testid="modal-remove-button"]');
+
+    await apiResponsePromise;
+  });
+
+  test('9. 로그인하고, 세부 능력 및 특기사항에서 table 맨 위의 row를 클릭해서 취소하기 버튼을 누르면 아무 일도 일어나지 않는다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.click('a[href="/manage-subject"]');
+
+    await page.locator('table tbody tr').first().click();
+
+    const inputField = page.locator('input[data-testid="student-name-input"]');
+    await expect(inputField).toBeVisible();
+
+    await page.click('button:has-text("취소하기")');
+
+    await expect(inputField).not.toBeVisible();
+  });
+
+  test('10. 엑셀로 내보내기 버튼을 누르면 현재 있는 data가 엑셀로 추출되어서 다운로드 받아진다.', async ({
+    page,
+  }) => {
+    await performLogin(page, 'test@edukit.co.kr', 'password1234!');
+    await page.click('a[href="/manage-subject"]');
+
+    const exportButton = page.locator('button:has-text("엑셀로 내보내기")');
+    await expect(exportButton).toBeEnabled();
+
+    const downloadPromise = page.waitForEvent('download');
+    await exportButton.click();
+    const download = await downloadPromise;
+
+    const fileName = download.suggestedFilename();
+    expect(fileName).toContain('.xlsx');
+    expect(fileName).toContain('세부능력 및 특기사항');
+  });
+});

--- a/tests/write-records/write-records.spec.ts
+++ b/tests/write-records/write-records.spec.ts
@@ -55,8 +55,6 @@ test.describe('생활기록부 작성 E2E 테스트', () => {
 
     const downloadPath = await download.path();
 
-    await page.locator('[data-testid="excel-upload"]').click();
-
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles(downloadPath);
 
@@ -148,8 +146,6 @@ test.describe('생활기록부 작성 E2E 테스트', () => {
     await performLogin(page, 'test@edukit.co.kr', 'password1234!');
     await page.goto('/write-behavior');
     await page.click('button:has-text("생활기록부 관리하기")');
-
-    await page.locator('[data-testid="excel-upload"]').click();
 
     await expectAlertMessage(page, '엑셀 파일을 처리하는 중 오류가 발생했습니다.');
 


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-261]

## 🌱 주요 변경 사항

1. test를 위해 나의 학생 관리에서 사용되는 컴포넌트에 data-testid 속성 추가
2. record 를 추가하는 컴포넌트에서 description 필드를 기존 input에서 textarea로 리팩토링
3. 생기부 mock 데이터 실제 api 응답과 동일하게 리팩토링 및 msw get-records에 accessToken 검증 로직 추가
4. 생활기록부 작성 테스트 코드에서 엑셀 업로드 테스트 케이스 중 의미 없는 코드 제거 및 accessToken을 가져오는 msw helper 로직에서도 의미 없는 분기 처리 코드 제거
5. 나의 학생 관리 기능 테스트 코드 작성 및 테스트 진행

## student-manage 테스트 케이스
1. 로그인이 안되어 있는 상태에서 사이드바의 나의 학생 관리 하위 항목인 세부능력 및 특기사항을 클릭해서 들어가면 로그인이 필요합니다 라는 텍스트가 나오고, 학생 추가/엑셀로 내보내기 버튼이 보이지 않고, 로그인 버튼을 누르면 로그인 페이지로 이동한다.
2. 이메일 인증하지 않은 유저가 로그인 하고 사이드바의 나의 학생 관리 하위 항목인 행동 특성 및 종합의견을 클릭해서 들어가면 이메일을 인증해주세요 라는 텍스트가 나오고, 학생 추가/엑셀로 내보내기 버튼이 보이지 않고, 로그아웃을 하고 다시 들어가면 로그인이 필요합니다 라는 텍스트가 나온다.
3. 로그인 하고 사이드바의 나의 학생 관리 하위 항목인 행동 특성 및 종합의견을 클릭해서 들어가면 엑셀로 내보내기 버튼이 disabled 상태이고, 학생 데이터가 0개이며 추가하기 버튼만 나온다.
4. 로그인하고 manage-behavior 링크로 들어와서 학생 등록하고 생활기록부 관리하기 버튼을 클릭해서 템플릿을 다운로드 하고, 파일 업로드를 클릭해서 해당 템플릿 excel 파일을 올리면 이름 목록이 잘 나오고, 생성하기버튼을 누르면 api 응답이 200으로 잘 내려온다.
5. 엑셀 업로드 시 잘못된 파일 형식을 업로드하면, 엑셀 파일을 처리하는 중 오류가 발생했습니다. 라는 alert 창이 나온다.
6. 추가하기 버튼을 눌러서 학번, 이름, 내용을 채워넣고 추가하기 버튼을 누르면 api 응답이 200으로 내려온다.
7. 로그인하고, 세부 능력 및 특기사항에서 table 맨 위의 row를 클릭해서 이름을 수정하고 수정하기 버튼을 누르면 api 응답이 200으로 내려온다.
8. 로그인하고, 세부 능력 및 특기사항에서 table 맨 위의 row를 클릭해서 삭제하기 버튼을 누르면 api응답이 200으로 내려온다.
9. 로그인하고, 세부 능력 및 특기사항에서 table 맨 위의 row를 클릭해서 취소하기 버튼을 누르면 아무 일도 일어나지 않는다.
10. 엑셀로 내보내기 버튼을 누르면 현재 있는 data가 엑셀로 추출되어서 다운로드 받아진다.


## 📸 스크린샷 (선택)
<img width="1273" height="794" alt="스크린샷 2025-07-21 오전 11 03 59" src="https://github.com/user-attachments/assets/f6942cbc-ae33-45b0-a44b-66ee19c10a66" />


[EDMT-261]: https://bbangbbangz.atlassian.net/browse/EDMT-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 테스트**
  * 학생 관리 페이지의 다양한 시나리오(비로그인, 이메일 미인증, 학생 추가/수정/삭제, 엑셀 업로드 및 다운로드 등)에 대한 E2E 테스트가 추가되었습니다.

* **버그 수정**
  * 학생 추가 버튼에서 데이터 로딩 및 오류 상태 처리 방식이 개선되었습니다.
  * 삭제 확인 모달, 학생 정보 입력 및 수정 폼에 테스트용 data-testid 속성이 추가되었습니다.

* **기능 개선**
  * 학생 추가 시 설명 입력란이 한 줄 입력에서 자동 높이 조절이 가능한 다중 줄 텍스트 영역으로 변경되었습니다.
  * 학생 데이터 상수(RECORD_DATA)의 구조가 변경되어 학생 목록이 객체로 감싸집니다.
  * API 응답에서 토큰 인증 및 권한 검증 로직이 강화되었습니다.

* **테스트**
  * 엑셀 업로드 테스트에서 불필요한 클릭 동작이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->