### PR TITLE
[EDMT-334] 공지사항 어드민 기능 통합 테스트 코드 작성 및 테스트 진행

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -24,12 +24,15 @@ jest.mock('next/navigation', () => ({
 
 // AuthProvider Mock
 const mockSetAuthData = jest.fn();
+const mockUseAuth = jest.fn(() => ({
+  setAuthData: mockSetAuthData,
+  accessToken: null,
+  isAdmin: null,
+}));
+
 jest.mock('@/shared/providers/auth-provider', () => ({
-  useAuth: () => ({
-    setAuthData: mockSetAuthData,
-    accessToken: null,
-    isAdmin: null,
-  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+  useAuth: () => mockUseAuth(),
 }));
 
 // 전역 변수로 mock 함수들을 사용할 수 있도록 설정
@@ -38,6 +41,7 @@ jest.mock('@/shared/providers/auth-provider', () => ({
 (global as any).mockBack = mockBack;
 (global as any).mockRefresh = mockRefresh;
 (global as any).mockSetAuthData = mockSetAuthData;
+(global as any).mockUseAuth = mockUseAuth;
 
 // 전역으로 mock을 초기화 할 수 있는 함수
 (global as any).clearAllTestMocks = () => {
@@ -47,4 +51,10 @@ jest.mock('@/shared/providers/auth-provider', () => ({
   mockBack.mockClear();
   mockRefresh.mockClear();
   mockSetAuthData.mockClear();
+  // mockUseAuth 초기화 시 기본값으로 재설정
+  mockUseAuth.mockReturnValue({
+    setAuthData: mockSetAuthData,
+    accessToken: null,
+    isAdmin: null,
+  });
 };

--- a/src/__tests__/jest-global.d.ts
+++ b/src/__tests__/jest-global.d.ts
@@ -21,6 +21,8 @@ declare global {
   const mockBack: jest.MockedFunction<any>;
   const mockRefresh: jest.MockedFunction<any>;
   const mockSetAuthData: jest.MockedFunction<any>;
+  const mockUseAuth: jest.Mock;
+
   const clearAllTestMocks: () => void;
 }
 

--- a/src/__tests__/utils/test-utils.tsx
+++ b/src/__tests__/utils/test-utils.tsx
@@ -1,7 +1,10 @@
 import { type ReactElement } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, type RenderOptions } from '@testing-library/react';
+import { render, type RenderOptions, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Login from '@/domains/auth/components/login/login';
 
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient({
@@ -21,5 +24,75 @@ const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
 
 const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
   render(ui, { wrapper: AllTheProviders, ...options });
+
+/**
+ * MSW를 활용한 어드민 계정 로그인 헬퍼 함수
+ * - MSW post-login.ts의 admin@edukit.co.kr / password1234 사용
+ * - 로그인 성공 후 mockUseAuth를 어드민 상태로 업데이트
+ * - DOM을 정리하여 다른 컴포넌트 렌더링에 영향을 주지 않음
+ */
+export const loginAsAdmin = async () => {
+  const user = userEvent.setup();
+  customRender(<Login />);
+
+  const emailInput = screen.getByPlaceholderText('이메일');
+  const passwordInput = screen.getByPlaceholderText('비밀번호');
+  const submitButton = screen.getByRole('button', { name: '로그인' });
+
+  await user.type(emailInput, 'admin@edukit.co.kr');
+  await user.type(passwordInput, 'password1234');
+  await user.click(submitButton);
+
+  await waitFor(() => {
+    expect(mockSetAuthData).toHaveBeenCalledWith(
+      expect.stringContaining('admin-access-token'),
+      true,
+    );
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  mockUseAuth.mockReturnValue({
+    accessToken: expect.stringContaining('admin-access-token'),
+    isAdmin: true,
+    setAuthData: mockSetAuthData,
+  });
+
+  cleanup();
+};
+
+/**
+ * MSW를 활용한 일반 사용자 계정 로그인 헬퍼 함수
+ * - MSW post-login.ts의 test@edukit.co.kr / password1234! 사용
+ * - 로그인 성공 후 mockUseAuth를 일반 사용자 상태로 업데이트
+ * - DOM을 정리하여 다른 컴포넌트 렌더링에 영향을 주지 않음
+ */
+export const loginAsUser = async () => {
+  const user = userEvent.setup();
+  customRender(<Login />);
+
+  const emailInput = screen.getByPlaceholderText('이메일');
+  const passwordInput = screen.getByPlaceholderText('비밀번호');
+  const submitButton = screen.getByRole('button', { name: '로그인' });
+
+  await user.type(emailInput, 'test@edukit.co.kr');
+  await user.type(passwordInput, 'password1234!');
+  await user.click(submitButton);
+
+  await waitFor(() => {
+    expect(mockSetAuthData).toHaveBeenCalledWith(
+      expect.stringContaining('user-access-token'),
+      false,
+    );
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  mockUseAuth.mockReturnValue({
+    accessToken: expect.stringContaining('user-access-token'),
+    isAdmin: false,
+    setAuthData: mockSetAuthData,
+  });
+
+  cleanup();
+};
 
 export { customRender as render };

--- a/src/domains/notice/__tests__/notice-admin.integration.test.tsx
+++ b/src/domains/notice/__tests__/notice-admin.integration.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render, loginAsAdmin, loginAsUser } from '@/__tests__/utils/test-utils';
+import EditDeleteNoticeButton from '@/domains/notice/components/edit-delete-notice-button';
+import EditNotice from '@/domains/notice/components/edit-notice';
+import WriteNotice from '@/domains/notice/components/write-notice';
+import WriteNoticeButton from '@/domains/notice/components/write-notice-button';
+import type { DetailNoticeResponse } from '@/domains/notice/types/notice';
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+const mockPostAdminNotice = jest.fn();
+const mockPatchAdminNotice = jest.fn();
+const mockDeleteAdminNotice = jest.fn();
+const mockGetHTML = jest.fn().mockReturnValue('');
+
+jest.mock('@/domains/notice/apis/mutations/use-post-admin-notice', () => ({
+  usePostAdminNotice: () => ({ mutate: mockPostAdminNotice }),
+}));
+
+jest.mock('@/domains/notice/apis/mutations/use-patch-admin-notice', () => ({
+  usePatchAdminNotice: () => ({ mutate: mockPatchAdminNotice }),
+}));
+
+jest.mock('@/domains/notice/apis/mutations/use-delete-admin-notice', () => ({
+  useDeleteAdminNotice: () => ({ mutate: mockDeleteAdminNotice }),
+}));
+
+jest.mock('@/shared/components/ui/editor/tiptap-editor', () => {
+  function MockTipTapEditor(props: any, ref: any) {
+    React.useImperativeHandle(ref, () => ({
+      getHTML: mockGetHTML,
+    }));
+
+    return React.createElement('div', {
+      'data-testid': 'tiptap-editor',
+      className: props.className,
+    });
+  }
+
+  return {
+    __esModule: true,
+    default: React.forwardRef(MockTipTapEditor),
+  };
+});
+
+const mockNoticeDetail: DetailNoticeResponse = {
+  noticeId: '1',
+  title: '테스트 공지사항',
+  content: '<p>테스트 내용입니다.</p>',
+  category: '공지',
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+describe('공지사항 어드민 기능 통합 테스트', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(async () => {
+    user = userEvent.setup();
+    clearAllTestMocks();
+
+    mockGetHTML.mockReturnValue('');
+
+    mockPostAdminNotice.mockImplementation(
+      (_, options) => options?.onSuccess && options.onSuccess(),
+    );
+    mockPatchAdminNotice.mockImplementation(
+      (_, options) => options?.onSuccess && options.onSuccess(),
+    );
+    mockDeleteAdminNotice.mockImplementation(
+      (_, options) => options?.onSuccess && options.onSuccess(),
+    );
+  });
+
+  describe('어드민 권한별 글쓰기 버튼 노출', () => {
+    it('비로그인 상태에서는 글쓰기 버튼이 없다', () => {
+      const { container } = render(<WriteNoticeButton />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('일반 사용자 로그인 시 글쓰기 버튼이 없다', async () => {
+      await loginAsUser();
+      const { container } = render(<WriteNoticeButton />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('어드민 로그인 시 글쓰기 버튼이 보인다', async () => {
+      await loginAsAdmin();
+      render(<WriteNoticeButton />);
+      expect(screen.getByText('글쓰기')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: '글쓰기' })).toHaveAttribute(
+        'href',
+        '/notice/write-notice',
+      );
+    });
+  });
+
+  describe('공지사항 작성 기능', () => {
+    beforeEach(async () => {
+      await loginAsAdmin();
+    });
+
+    it('작성 폼 렌더링 확인', () => {
+      render(<WriteNotice />);
+      expect(screen.getByText('공지')).toBeInTheDocument();
+      expect(screen.getByText('이벤트')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('제목')).toBeInTheDocument();
+      expect(screen.getByTestId('tiptap-editor')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '작성하기' })).toBeInTheDocument();
+    });
+
+    it('카테고리 선택이 정상적으로 동작한다', async () => {
+      render(<WriteNotice />);
+      const noticeButton = screen.getByText('공지');
+      const eventButton = screen.getByText('이벤트');
+
+      expect(noticeButton).toHaveClass('bg-slate-800');
+
+      await user.click(eventButton);
+
+      expect(eventButton).toHaveClass('bg-slate-800');
+      expect(noticeButton).toHaveClass('bg-white');
+    });
+
+    it.each([
+      ['제목만 입력', '테스트 제목', ''],
+      ['내용만 입력', '', '<p>테스트 내용입니다.</p>'],
+    ])(
+      '"%s" 상태에서 작성하기 클릭 시 제목과 내용을 모두 입력해달라는 alert 메세지가 표시된다',
+      async (_, title, content) => {
+        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+        render(<WriteNotice />);
+
+        if (title) {
+          const titleInput = screen.getByPlaceholderText('제목');
+          await user.type(titleInput, title);
+        }
+        if (content) {
+          mockGetHTML.mockReturnValue(content);
+        }
+
+        const submitButton = screen.getByRole('button', { name: '작성하기' });
+        await user.click(submitButton);
+
+        expect(alertSpy).toHaveBeenCalledWith('제목과 내용을 모두 입력해주세요.');
+        alertSpy.mockRestore();
+      },
+    );
+
+    it('이벤트 태그를 클릭하고, 제목 및 내용을 입력하고 작성하기 버튼을 클릭 시 공지사항 작성 api 요청이 성공하고 notice 페이지로 이동한다', async () => {
+      render(<WriteNotice />);
+      await user.click(screen.getByText('이벤트'));
+
+      const titleInput = screen.getByPlaceholderText('제목');
+      await user.type(titleInput, '테스트 공지사항 제목');
+
+      mockGetHTML.mockReturnValue('<p>테스트 내용입니다.</p>');
+
+      await user.click(screen.getByRole('button', { name: '작성하기' }));
+
+      expect(mockPostAdminNotice).toHaveBeenCalledWith(
+        {
+          title: '테스트 공지사항 제목',
+          content: '<p>테스트 내용입니다.</p>',
+          categoryId: 3,
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+      expect(mockPush).toHaveBeenNthCalledWith(2, '/notice');
+    });
+  });
+
+  describe('공지사항 수정/삭제 기능', () => {
+    beforeEach(async () => {
+      await loginAsAdmin();
+    });
+
+    it('일반 사용자일 때 수정/삭제 버튼이 보이지 않는다', async () => {
+      clearAllTestMocks();
+      await loginAsUser();
+
+      const { container } = render(<EditDeleteNoticeButton id="1" />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('어드민 시 수정/삭제 버튼 노출', () => {
+      render(<EditDeleteNoticeButton id="1" />);
+      expect(screen.getByText('수정하기')).toBeInTheDocument();
+      expect(screen.getByText('삭제하기')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: '수정하기' })).toHaveAttribute(
+        'href',
+        '/notice/edit-notice/1',
+      );
+    });
+
+    it('삭제 버튼 클릭 -> 모달 열림 -> 삭제 버튼 클릭 -> 삭제 api 요청이 성공하고 notice 페이지로 이동한다', async () => {
+      render(<EditDeleteNoticeButton id="1" />);
+
+      await user.click(screen.getByText('삭제하기'));
+
+      await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+
+      await user.click(screen.getByRole('button', { name: '삭제' }));
+
+      expect(mockDeleteAdminNotice).toHaveBeenCalledWith(
+        '1',
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+
+      expect(mockPush).toHaveBeenNthCalledWith(2, '/notice');
+    });
+
+    it('수정 폼에서 취소 버튼 클릭 시 이전 페이지로 이동한다', async () => {
+      render(<EditNotice notice={mockNoticeDetail} />);
+      await user.click(screen.getByRole('button', { name: '취소' }));
+      expect(mockBack).toHaveBeenCalled();
+    });
+
+    it('공지사항 수정을 수정하고 수정하기 버튼을 누르면 수정 api 요청이 성공하고 /notice/id 페이지로 이동한다.', async () => {
+      render(<EditNotice notice={mockNoticeDetail} />);
+
+      const titleInput = screen.getByDisplayValue('테스트 공지사항');
+      await user.clear(titleInput);
+      await user.type(titleInput, '수정된 테스트 공지사항');
+
+      await user.click(screen.getByText('이벤트'));
+
+      mockGetHTML.mockReturnValue('<p>수정된 테스트 내용입니다.</p>');
+
+      await user.click(screen.getByRole('button', { name: '수정하기' }));
+
+      expect(mockPatchAdminNotice).toHaveBeenCalledWith(
+        {
+          id: '1',
+          title: '수정된 테스트 공지사항',
+          content: '<p>수정된 테스트 내용입니다.</p>',
+          categoryId: 3,
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+
+      expect(mockPush).toHaveBeenNthCalledWith(2, '/notice/1');
+    });
+  });
+});


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-334]

## 🌱 주요 변경 사항

1. Auth Provider 코드 test.setup.ts 에 추가하여 테스트 시작 전에 수행되도록 하는 로직 추가
2. Test에 필요한 일반 유저 로그인 / 어드민 유저 로그인 기능 util 함수로 구현
3. 공지사항 어드민 기능 통합 테스트 코드 작성 및 테스트 진행

## 공지사항 어드민 기능 통합 테스트 케이스
### 어드민 권한별 글쓰기 버튼 노출 테스트

- **TC001**: 비로그인 상태에서 글쓰기 버튼 비노출
    - 예상결과: 버튼 컴포넌트 `null` 렌더링
- **TC002**: 일반 사용자 로그인 시 글쓰기 버튼 비노출
    - 예상결과: 버튼 컴포넌트 `null` 렌더링
- **TC003**: 어드민 로그인 시 글쓰기 버튼 노출
    - 예상결과: "글쓰기" 텍스트 및 `/notice/write-notice` 링크 확인

### 공지사항 작성 기능 테스트

- **TC004**: 작성 폼 렌더링 확인
    - 검증 요소: 카테고리 버튼(공지, 이벤트), 제목 입력창, 에디터, 작성하기 버튼
- **TC005**: 카테고리 버튼 클릭 시 선택 상태 변경 확인
    - 초기 상태: "공지" 선택됨
    - 이벤트: "이벤트" 클릭
    - 예상결과: "이벤트" 버튼 강조, "공지" 비활성화
- **TC006**: 제목만 입력한 경우 → alert 표시
    - 입력: 제목 입력, 내용 없음
    - 예상결과: "제목과 내용을 모두 입력해주세요." alert
- **TC007**: 내용만 입력한 경우 → alert 표시
    - 입력: 제목 없음, 내용 입력
    - 예상결과: "제목과 내용을 모두 입력해주세요." alert
- **TC008**: 제목 + 내용 입력 후 작성 시 API 호출 및 페이지 이동
    - 입력: 제목 입력, 내용 작성, "이벤트" 선택
    - 예상결과:
        - `mockPostAdminNotice` 호출
        - `/notice`로 리다이렉션 (`mockPush` 호출 확인)

### 공지사항 수정/삭제 기능 테스트

- **TC009**: 일반 사용자일 때 수정/삭제 버튼 비노출
    - 예상결과: 버튼 컴포넌트 `null` 렌더링
- **TC010**: 어드민일 때 수정/삭제 버튼 노출
    - 검증 요소: "수정하기", "삭제하기" 버튼 및 링크 `/notice/edit-notice/1`
- **TC011**: 삭제 버튼 클릭 시 확인 모달이 표시되고, 모달에서 삭제 버튼 클릭 시 API 호출 및 `/notice` 리다이렉션
    - 시나리오: "삭제하기" 클릭
    - 예상결과:
        - 모달(`role="dialog"`) 존재 확인
        - `mockDeleteAdminNotice` 호출
        - `/notice`로 리다이렉션 (`mockPush`)
- **TC013**: 수정 폼에서 "취소" 클릭 시 이전 페이지 이동
    - 예상결과: `mockBack()` 호출
- **TC014**: 제목 + 내용 수정 후 "수정하기" 클릭 시 API 호출 및 `/notice/1` 이동
    - 입력:
        - 제목 변경 → `수정된 테스트 공지사항`
        - 내용 변경 → `<p>수정된 테스트 내용입니다.</p>`
        - 카테고리 변경 → "이벤트"
    - 예상결과:
        - `mockPatchAdminNotice` 호출
        - `/notice/1`로 이동 (`mockPush` 확인)

## 📸 스크린샷 (선택)
<img width="1057" height="347" alt="스크린샷 2025-08-05 오전 1 34 41" src="https://github.com/user-attachments/assets/370575b5-2836-45b5-8613-38047a970d94" />


