### PR TITLE
[EDMT-354] profile 기능 단위/통합 테스트 진행

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "generate:msw": "tsx scripts/generate-msw.ts",
     "mock-server": "tsx src/shared/mocks/server.ts",
     "test": "jest",
+    "test:ci": "jest --config jest.config.ts --coverage --watchAll=false --passWithNoTests --verbose --ci",
     "test:watch": "jest --watch",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/src/domains/auth/__tests__/login.test.tsx
+++ b/src/domains/auth/__tests__/login.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@/__tests__/utils/test-utils';
 
 import Login from '../components/login/login';
 
-describe('로그인 통합 테스트', () => {
+describe('login 컴포넌트 단위 테스트', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/src/domains/auth/__tests__/signup.test.tsx
+++ b/src/domains/auth/__tests__/signup.test.tsx
@@ -1,14 +1,11 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { setupMSW } from '@/__tests__/utils/msw-setup';
 import { render } from '@/__tests__/utils/test-utils';
 
 import Signup from '../components/signup/signup';
 
-setupMSW();
-
-describe('회원가입 통합 테스트', () => {
+describe('signup 컴포넌트 단위 테스트', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/src/domains/notice/__tests__/notice-admin.integration.test.tsx
+++ b/src/domains/notice/__tests__/notice-admin.integration.test.tsx
@@ -14,22 +14,7 @@ jest.mock('next/cache', () => ({
   revalidatePath: jest.fn(),
 }));
 
-const mockPostAdminNotice = jest.fn();
-const mockPatchAdminNotice = jest.fn();
-const mockDeleteAdminNotice = jest.fn();
 const mockGetHTML = jest.fn().mockReturnValue('');
-
-jest.mock('@/domains/notice/apis/mutations/use-post-admin-notice', () => ({
-  usePostAdminNotice: () => ({ mutate: mockPostAdminNotice }),
-}));
-
-jest.mock('@/domains/notice/apis/mutations/use-patch-admin-notice', () => ({
-  usePatchAdminNotice: () => ({ mutate: mockPatchAdminNotice }),
-}));
-
-jest.mock('@/domains/notice/apis/mutations/use-delete-admin-notice', () => ({
-  useDeleteAdminNotice: () => ({ mutate: mockDeleteAdminNotice }),
-}));
 
 jest.mock('@/shared/components/ui/editor/tiptap-editor', () => {
   function MockTipTapEditor(props: any, ref: any) {
@@ -57,7 +42,7 @@ const mockNoticeDetail: DetailNoticeResponse = {
   createdAt: '2024-01-01T00:00:00Z',
 };
 
-describe('공지사항 어드민 기능 통합 테스트', () => {
+describe('notice-admin 기능 통합 테스트', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(async () => {
@@ -65,16 +50,6 @@ describe('공지사항 어드민 기능 통합 테스트', () => {
     clearAllTestMocks();
 
     mockGetHTML.mockReturnValue('');
-
-    mockPostAdminNotice.mockImplementation(
-      (_, options) => options?.onSuccess && options.onSuccess(),
-    );
-    mockPatchAdminNotice.mockImplementation(
-      (_, options) => options?.onSuccess && options.onSuccess(),
-    );
-    mockDeleteAdminNotice.mockImplementation(
-      (_, options) => options?.onSuccess && options.onSuccess(),
-    );
   });
 
   describe('어드민 권한별 글쓰기 버튼 노출', () => {
@@ -166,15 +141,7 @@ describe('공지사항 어드민 기능 통합 테스트', () => {
 
       await user.click(screen.getByRole('button', { name: '작성하기' }));
 
-      expect(mockPostAdminNotice).toHaveBeenCalledWith(
-        {
-          title: '테스트 공지사항 제목',
-          content: '<p>테스트 내용입니다.</p>',
-          categoryId: 3,
-        },
-        expect.objectContaining({ onSuccess: expect.any(Function) }),
-      );
-      expect(mockPush).toHaveBeenNthCalledWith(2, '/notice');
+      expect(mockPush).toHaveBeenCalledWith('/notice');
     });
   });
 
@@ -210,12 +177,7 @@ describe('공지사항 어드민 기능 통합 테스트', () => {
 
       await user.click(screen.getByRole('button', { name: '삭제' }));
 
-      expect(mockDeleteAdminNotice).toHaveBeenCalledWith(
-        '1',
-        expect.objectContaining({ onSuccess: expect.any(Function) }),
-      );
-
-      expect(mockPush).toHaveBeenNthCalledWith(2, '/notice');
+      expect(mockPush).toHaveBeenCalledWith('/notice');
     });
 
     it('수정 폼에서 취소 버튼 클릭 시 이전 페이지로 이동한다', async () => {
@@ -237,17 +199,7 @@ describe('공지사항 어드민 기능 통합 테스트', () => {
 
       await user.click(screen.getByRole('button', { name: '수정하기' }));
 
-      expect(mockPatchAdminNotice).toHaveBeenCalledWith(
-        {
-          id: '1',
-          title: '수정된 테스트 공지사항',
-          content: '<p>수정된 테스트 내용입니다.</p>',
-          categoryId: 3,
-        },
-        expect.objectContaining({ onSuccess: expect.any(Function) }),
-      );
-
-      expect(mockPush).toHaveBeenNthCalledWith(2, '/notice/1');
+      expect(mockPush).toHaveBeenCalledWith('/notice/1');
     });
   });
 });

--- a/src/domains/profile/__tests__/basic-info-email.test.tsx
+++ b/src/domains/profile/__tests__/basic-info-email.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render, loginAsUser } from '@/__tests__/utils/test-utils';
+import BasicInfo from '@/domains/profile/components/basic-info';
+
+describe('basic-info-email 컴포넌트 단위 테스트', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  global.alert = jest.fn();
+  beforeEach(async () => {
+    user = userEvent.setup();
+    clearAllTestMocks();
+
+    await loginAsUser();
+
+    render(<BasicInfo email="test@edukit.co.kr" />);
+
+    (global.alert as jest.Mock).mockClear();
+  });
+
+  it('이메일 정보가 올바르게 표시된다', () => {
+    expect(screen.getByText('test@edukit.co.kr')).toBeInTheDocument();
+    expect(screen.getByTestId('email-edit-button')).toBeInTheDocument();
+  });
+
+  it('이메일 수정 모드로 전환할 수 있다', async () => {
+    await user.click(screen.getByTestId('email-edit-button'));
+
+    expect(screen.getByPlaceholderText('새로운 이메일을 입력해주세요')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '저장' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+  });
+
+  it('유효하지 않은 이메일 형식 시 에러 메시지가 표시되고, 이메일 수정 input의 border가 빨간색으로 변한다.', async () => {
+    await user.click(screen.getByTestId('email-edit-button'));
+
+    const emailInput = screen.getByPlaceholderText('새로운 이메일을 입력해주세요');
+
+    await user.clear(emailInput);
+    await user.type(emailInput, 'invalid-email');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(screen.getByText('이메일 형식이 유효하지 않습니다.')).toBeInTheDocument();
+    expect(emailInput).toHaveClass('border-red-500');
+  });
+
+  it('교직 이메일이 아닌 경우 에러 메시지가 표시되고, 이메일 수정 input의 border가 빨간색으로 변한다.', async () => {
+    await user.click(screen.getByTestId('email-edit-button'));
+
+    const emailInput = screen.getByPlaceholderText('새로운 이메일을 입력해주세요');
+
+    await user.clear(emailInput);
+    await user.type(emailInput, 'new123@daum.net');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(screen.getByText('교직 이메일이 아닙니다.')).toBeInTheDocument();
+    expect(emailInput).toHaveClass('border-red-500');
+  });
+
+  it('중복된 이메일 사용 시 에러 메시지가 표시된다', async () => {
+    await user.click(screen.getByTestId('email-edit-button'));
+
+    const emailInput = screen.getByPlaceholderText('새로운 이메일을 입력해주세요');
+
+    await user.clear(emailInput);
+    await user.type(emailInput, 'test@edukit.co.kr');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(global.alert).toHaveBeenCalledWith('이미 등록된 회원입니다.');
+  });
+
+  it('이메일 변경 성공 시 성공 메시지가 표시되고 뷰 모드로 전환된다', async () => {
+    await user.click(screen.getByTestId('email-edit-button'));
+
+    const emailInput = screen.getByPlaceholderText('새로운 이메일을 입력해주세요');
+
+    await user.clear(emailInput);
+    await user.type(emailInput, 'new123@edukit.co.kr');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(global.alert).toHaveBeenCalledWith('이메일이 성공적으로 변경되었습니다.');
+  });
+
+  it('이메일 수정을 취소할 수 있다', async () => {
+    await user.click(screen.getByTestId('email-edit-button'));
+
+    await user.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(screen.queryByPlaceholderText('새로운 이메일을 입력해주세요')).not.toBeInTheDocument();
+    expect(screen.getByTestId('email-edit-button')).toBeInTheDocument();
+  });
+
+  it('이메일 수정 모드일 때 비밀번호 수정 버튼이 숨겨진다', async () => {
+    const emailEditButton = screen.getByTestId('email-edit-button');
+    await user.click(emailEditButton);
+
+    expect(screen.queryByTestId('password-edit-button')).not.toBeInTheDocument();
+  });
+});

--- a/src/domains/profile/__tests__/basic-info-password.test.tsx
+++ b/src/domains/profile/__tests__/basic-info-password.test.tsx
@@ -1,0 +1,128 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render, loginAsUser } from '@/__tests__/utils/test-utils';
+import BasicInfo from '@/domains/profile/components/basic-info';
+
+describe('basic-info-password 컴포넌트 단위 테스트', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  global.alert = jest.fn();
+
+  beforeEach(async () => {
+    user = userEvent.setup();
+    clearAllTestMocks();
+
+    await loginAsUser();
+
+    render(<BasicInfo email="test@edukit.co.kr" />);
+
+    (global.alert as jest.Mock).mockClear();
+
+    await user.click(screen.getByTestId('password-edit-button'));
+  });
+
+  it('비밀번호 수정 버튼을 클릭하면 모든 비밀번호 입력 필드가 렌더링된다', async () => {
+    expect(screen.getByPlaceholderText('현재 비밀번호')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('새 비밀번호')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('새 비밀번호 확인')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: '저장' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+  });
+
+  it('필수 필드 누락 시 에러 메시지가 표시되고, 비밀번호 input들의 border가 빨간색으로 변한다', async () => {
+    const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
+    const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
+    const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(screen.getByTestId('current-password-error')).toBeInTheDocument();
+    expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-password-error')).toBeInTheDocument();
+    expect(currentPasswordInput).toHaveClass('border-red-500');
+    expect(newPasswordInput).toHaveClass('border-red-500');
+    expect(confirmPasswordInput).toHaveClass('border-red-500');
+  });
+
+  it('새 비밀번호 유효성 검사가 올바르게 동작하고, 새 비밀번호 input들의 border가 빨간색으로 변한다', async () => {
+    const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
+    const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
+    const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+
+    await user.type(currentPasswordInput, 'password123!');
+    await user.type(newPasswordInput, '123');
+    await user.type(confirmPasswordInput, '123');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
+    expect(newPasswordInput).toHaveClass('border-red-500');
+  });
+
+  it('새 비밀번호 확인이 일치하지 않을 때 에러 메시지가 표시되고, 새 비밀번호 확인 border가 빨간색으로 변한다', async () => {
+    const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
+    const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
+    const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+
+    await user.type(currentPasswordInput, 'password123!');
+    await user.type(newPasswordInput, 'newPassword123!');
+    await user.type(confirmPasswordInput, 'differentPassword');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(screen.getByTestId('confirm-password-error')).toBeInTheDocument();
+    expect(confirmPasswordInput).toHaveClass('border-red-500');
+  });
+
+  it('현재 비밀번호가 틀린 경우 에러 메시지가 표시된다', async () => {
+    const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
+    const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
+    const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+
+    await user.type(currentPasswordInput, 'password1234');
+    await user.type(newPasswordInput, 'newPassword123!');
+    await user.type(confirmPasswordInput, 'newPassword123!');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(global.alert).toHaveBeenCalledWith(
+      '현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
+    );
+  });
+
+  it('기존 비밀번호와 동일한 새 비밀번호 사용 시 에러 메시지가 표시된다', async () => {
+    const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
+    const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
+    const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+
+    await user.type(currentPasswordInput, 'password123!');
+    await user.type(newPasswordInput, 'password123!');
+    await user.type(confirmPasswordInput, 'password123!');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(global.alert).toHaveBeenCalledWith(
+      '새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다.',
+    );
+  });
+
+  it('정상적인 비밀번호 변경이 성공한다', async () => {
+    const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
+    const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
+    const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+
+    await user.type(currentPasswordInput, 'password123!');
+    await user.type(newPasswordInput, 'newPassword123!');
+    await user.type(confirmPasswordInput, 'newPassword123!');
+    await user.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(global.alert).toHaveBeenCalledWith('비밀번호가 성공적으로 변경되었습니다.');
+  });
+
+  it('비밀번호 수정을 취소할 수 있다', async () => {
+    await user.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(screen.queryByPlaceholderText('현재 비밀번호')).not.toBeInTheDocument();
+    expect(screen.getByTestId('password-edit-button')).toBeInTheDocument();
+  });
+
+  it('비밀번호 수정 모드일 때 이메일 수정 버튼이 숨겨진다', async () => {
+    expect(screen.queryByTestId('email-edit-button')).not.toBeInTheDocument();
+  });
+});

--- a/src/domains/profile/__tests__/profile-edit.test.tsx
+++ b/src/domains/profile/__tests__/profile-edit.test.tsx
@@ -1,0 +1,219 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render, loginAsUser } from '@/__tests__/utils/test-utils';
+import ProfileEdit from '@/domains/profile/components/profile-edit';
+import type { ProfileResponse } from '@/domains/profile/types/profile';
+
+const mockProfile: ProfileResponse = {
+  nickname: '이승섭',
+  email: 'test@edukit.co.kr',
+  subject: '수학',
+  school: 'middle',
+  isTeacherVerified: true,
+};
+
+global.alert = jest.fn();
+
+describe('profile-edit 컴포넌트 단위 테스트', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  const mockOnChangeView = jest.fn();
+
+  beforeEach(async () => {
+    user = userEvent.setup();
+    mockOnChangeView.mockClear();
+    clearAllTestMocks();
+
+    await loginAsUser();
+
+    render(<ProfileEdit profile={mockProfile} onChangeView={mockOnChangeView} />);
+
+    (global.alert as jest.Mock).mockClear();
+  });
+
+  describe('닉네임 유효성 검사', () => {
+    it('닉네임이 비어있으면 중복 확인과 저장 버튼이 비활성화된다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const checkButton = screen.getByRole('button', { name: '중복 확인' });
+      const saveButton = screen.getByRole('button', { name: '저장' });
+
+      await user.clear(nicknameInput);
+
+      expect(checkButton).toBeDisabled();
+      expect(saveButton).toBeDisabled();
+    });
+
+    it('닉네임을 입력하면 중복 확인 버튼이 활성화된다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const checkButton = screen.getByRole('button', { name: '중복 확인' });
+
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, 'ㅇㅇ');
+
+      expect(checkButton).toBeEnabled();
+    });
+
+    it('금칙어가 포함된 닉네임에 대해 에러 메시지가 표시된다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const checkButton = screen.getByRole('button', { name: '중복 확인' });
+
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, 'ㅇㅇ');
+      await user.click(checkButton);
+
+      await waitFor(() => {
+        expect(global.alert).toHaveBeenCalledWith(
+          '금칙어가 들어갔습니다. 다른 닉네임을 사용해주세요.',
+        );
+      });
+    });
+
+    it('중복된 닉네임에 대해 에러 메시지가 표시된다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const checkButton = screen.getByRole('button', { name: '중복 확인' });
+
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, '선생님1');
+      await user.click(checkButton);
+
+      await waitFor(() => {
+        expect(global.alert).toHaveBeenCalledWith('현재 사용 중인 닉네임입니다.');
+      });
+    });
+
+    it('사용 가능한 닉네임에 대해 성공 메시지가 표시되고 저장 버튼이 활성화된다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const checkButton = screen.getByRole('button', { name: '중복 확인' });
+      const saveButton = screen.getByRole('button', { name: '저장' });
+
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, '선생님123');
+      await user.click(checkButton);
+
+      await waitFor(() => {
+        expect(global.alert).toHaveBeenCalledWith('사용 가능한 닉네임입니다!');
+      });
+
+      await waitFor(() => {
+        expect(saveButton).toBeEnabled();
+      });
+    });
+  });
+
+  describe('과목 및 학교 선택', () => {
+    it('과목 드롭다운이 올바르게 동작한다', async () => {
+      const subjectButton = screen.getByRole('button', { name: '수학' });
+
+      await user.click(subjectButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('영어')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('영어'));
+
+      expect(subjectButton).toHaveTextContent('영어');
+    });
+
+    it('학교 유형 선택이 올바르게 동작한다', async () => {
+      const middleSchoolButton = screen.getByText('중학교');
+      const highSchoolButton = screen.getByText('고등학교');
+
+      expect(middleSchoolButton.closest('button')).toHaveClass('bg-slate-800');
+      expect(highSchoolButton.closest('button')).toHaveClass('bg-slate-200');
+
+      await user.click(highSchoolButton);
+
+      await waitFor(() => {
+        expect(highSchoolButton.closest('button')).toHaveClass('bg-slate-800');
+        expect(middleSchoolButton.closest('button')).toHaveClass('bg-slate-200');
+      });
+    });
+  });
+
+  describe('프로필 저장', () => {
+    let requestSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      requestSpy = jest.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+      requestSpy.mockRestore();
+    });
+
+    it('프로필 정보 저장이 성공하면 API 요청이 발생하고 onChangeView가 호출된다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const checkButton = screen.getByRole('button', { name: '중복 확인' });
+      const saveButton = screen.getByRole('button', { name: '저장' });
+
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, '새로운닉네임');
+      await user.click(checkButton);
+
+      expect(global.alert).toHaveBeenCalledWith('사용 가능한 닉네임입니다!');
+
+      const subjectButton = screen.getByRole('button', { name: '수학' });
+      await user.click(subjectButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('영어')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('영어'));
+      expect(subjectButton).toHaveTextContent('영어');
+
+      const middleSchoolButton = screen.getByText('중학교');
+      const highSchoolButton = screen.getByText('고등학교');
+
+      expect(middleSchoolButton.closest('button')).toHaveClass('bg-slate-800');
+      expect(highSchoolButton.closest('button')).toHaveClass('bg-slate-200');
+
+      await user.click(highSchoolButton);
+
+      await waitFor(() => {
+        expect(highSchoolButton.closest('button')).toHaveClass('bg-slate-800');
+        expect(middleSchoolButton.closest('button')).toHaveClass('bg-slate-200');
+      });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(requestSpy).toHaveBeenCalledWith(
+          expect.stringContaining('/api/v1/users/profile'),
+          expect.objectContaining({
+            method: 'PATCH',
+            body: expect.stringContaining('"nickname":"새로운닉네임"'),
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockOnChangeView).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('닉네임을 원래대로 되돌리면 중복 확인 없이도 저장할 수 있다', async () => {
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요');
+      const saveButton = screen.getByRole('button', { name: '저장' });
+
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, '임시변경');
+      await user.clear(nicknameInput);
+      await user.type(nicknameInput, '이승섭');
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(requestSpy).toHaveBeenCalledWith(
+          expect.stringContaining('/api/v1/users/profile'),
+          expect.objectContaining({
+            method: 'PATCH',
+          }),
+        );
+      });
+
+      expect(global.alert).not.toHaveBeenCalledWith('닉네임 중복확인을 해주세요.');
+    });
+  });
+});

--- a/src/domains/profile/__tests__/profile.integration.test.tsx
+++ b/src/domains/profile/__tests__/profile.integration.test.tsx
@@ -1,0 +1,112 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render, loginAsUser, loginAsUnverifiedUser } from '@/__tests__/utils/test-utils';
+import Mypage from '@/domains/profile/components/mypage';
+
+global.alert = jest.fn();
+
+describe('profile 기능 통합 테스트', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(async () => {
+    user = userEvent.setup();
+    clearAllTestMocks();
+  });
+
+  it('비로그인 상태에서 마이페이지에 접근하면 로딩 스피너가 나오다가, 로그인 안내 메시지가 표시된다', async () => {
+    render(<Mypage />);
+
+    await waitFor(
+      () => {
+        const loading = document.querySelector('[class*="animate-spin"]');
+        expect(loading).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(screen.getByText('로그인 후 접근 가능합니다.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '로그인하기' })).toHaveAttribute('href', '/login');
+  });
+
+  it('로그인 상태에서는 프로필 정보가 정상적으로 표시된다', async () => {
+    await loginAsUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('내 프로필')).toBeInTheDocument();
+    expect(screen.getByText('기본 정보')).toBeInTheDocument();
+
+    expect(screen.getByText('인증 상태 :')).toBeInTheDocument();
+    expect(screen.getByText('과목 :')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: '프로필 수정하기' })).toBeInTheDocument();
+  });
+
+  it('프로필 수정하기 버튼을 누르면 profile-edit 컴포넌트가 정상적으로 렌더링된다', async () => {
+    await loginAsUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: '프로필 수정하기' }));
+
+    expect(screen.getByText('닉네임')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('닉네임을 입력하세요')).toBeInTheDocument();
+    expect(screen.getByText('학교')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '중복 확인' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '저장' })).toBeInTheDocument();
+  });
+
+  it('프로필 수정하기에서 취소 버튼을 누르면 profile-view 컴포넌트가 정상적으로 렌더링된다', async () => {
+    await loginAsUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: '프로필 수정하기' }));
+
+    await user.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(screen.getByText('내 프로필')).toBeInTheDocument();
+
+    expect(screen.getByText('인증 상태 :')).toBeInTheDocument();
+    expect(screen.getByText('과목 :')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: '프로필 수정하기' })).toBeInTheDocument();
+  });
+
+  it('교사 미인증 유저가 교사 인증 필요 버튼을 클릭하면 이메일이 발송되었다는 모달창이 나온다', async () => {
+    await loginAsUnverifiedUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    const certificationButton = screen.getByText('교사 인증 필요');
+    await user.click(certificationButton);
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    expect(screen.getByText('이메일이 발송되었습니다')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    expect(screen.getByText('내 프로필')).toBeInTheDocument();
+  });
+});

--- a/src/domains/profile/apis/queries/use-get-profile.ts
+++ b/src/domains/profile/apis/queries/use-get-profile.ts
@@ -11,5 +11,6 @@ export const useGetProfile = () => {
   return useQuery<ProfileResponse>({
     queryKey: ['profile'],
     queryFn: () => getProfile(),
+    retry: 1,
   });
 };


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-354]

## 🌱 주요 변경 사항

1. ci 환경에서의 테스트 스크립트 추가
2. 테스트 환경에서 어드민, 인증 유저, 미인증 유저 로그인 util 함수 리팩토링 및 setAuthContext 의존성 추가
3. 로그인, 회원가입 테스트 코드 파일명 수정
4. 공지사항 어드민 통합 테스트 코드 mock 함수가 아닌 msw 코드 활용하도록 리팩토링
5. 프로필 가져오는 api retry 횟수 1로 수정
6. profile 기능 단위 / 통합 테스트 진행

## basic-info-email 컴포넌트 단위 테스트 케이스
### **TC001**: 이메일 정보가 올바르게 표시된다

- **테스트 조건**: 초기 렌더링 상태
- **검증 요소**:
    - 이메일 텍스트 `test@edukit.co.kr` 표시
    - 이메일 수정 버튼(`email-edit-button`) 존재

### **TC002**: 이메일 수정 모드로 전환할 수 있다

- **이벤트**: 이메일 수정 버튼 클릭
- **예상 결과**:
    - 이메일 입력창(`새로운 이메일을 입력해주세요`) 표시
    - "저장" 버튼 표시
    - "취소" 버튼 표시

### **TC003**: 유효하지 않은 이메일 형식 시 에러 메시지 표시 및 테두리 색상 변경

- **입력**: `invalid-email` (잘못된 형식)
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - 에러 메시지: "이메일 형식이 유효하지 않습니다."
    - Input 테두리 스타일: `border-red-500` 클래스 적용

### **TC004**: 교직 이메일이 아닌 경우 에러 메시지 표시 및 테두리 색상 변경

- **입력**: `new123@daum.net` (일반 이메일)
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - 에러 메시지: "교직 이메일이 아닙니다."
    - Input 테두리 스타일: `border-red-500` 클래스 적용

### **TC005**: 중복된 이메일 사용 시 에러 메시지가 표시된다

- **입력**: `test@edukit.co.kr` (기존 이메일과 동일)
- **이벤트**: 저장 버튼 클릭
- **예상 결과**: Alert 메시지 "이미 등록된 회원입니다."

### **TC006**: 이메일 변경 성공 시 성공 메시지 표시 및 뷰 모드 전환

- **입력**: `new123@edukit.co.kr` (유효한 새 이메일)
- **이벤트**: 저장 버튼 클릭
- **예상 결과**: Alert 메시지 "이메일이 성공적으로 변경되었습니다."

### **TC007**: 이메일 수정을 취소할 수 있다

- **이벤트**: 취소 버튼 클릭
- **예상 결과**:
    - 이메일 입력창 숨김
    - 이메일 수정 버튼(`email-edit-button`) 다시 표시

### **TC008**: 이메일 수정 모드일 때 비밀번호 수정 버튼이 숨겨진다

- **테스트 조건**: 이메일 수정 모드 진입
- **예상 결과**: 비밀번호 수정 버튼(`password-edit-button`) 비표시

## basic-info-password 컴포넌트 단위 테스트 케이스
### **TC001**: 비밀번호 수정 버튼을 클릭하면 모든 비밀번호 입력 필드가 렌더링된다

- **테스트 조건**: 비밀번호 수정 버튼 클릭 후
- **검증 요소**:
    - 현재 비밀번호 입력창(`현재 비밀번호`) 표시
    - 새 비밀번호 입력창(`새 비밀번호`) 표시
    - 새 비밀번호 확인 입력창(`새 비밀번호 확인`) 표시
    - "저장" 버튼 표시
    - "취소" 버튼 표시

### **TC002**: 필수 필드 누락 시 에러 메시지 표시 및 테두리 색상 변경

- **입력**: 모든 필드 빈 상태
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - 에러 메시지: `current-password-error`, `new-password-error`, `confirm-password-error` 표시
    - Input 테두리 스타일: 모든 입력창에 `border-red-500` 클래스 적용

### **TC003**: 새 비밀번호 유효성 검사가 올바르게 동작하고, 새 비밀번호 input의 테두리가 빨간색으로 변한다

- **입력**:
    - 현재 비밀번호: `password123!`
    - 새 비밀번호: `123` (유효하지 않은 형식)
    - 새 비밀번호 확인: `123`
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - 에러 메시지: `new-password-error` 표시
    - Input 테두리 스타일: 새 비밀번호 입력창에 `border-red-500` 클래스 적용

### **TC004**: 새 비밀번호 확인이 일치하지 않을 때 에러 메시지 표시 및 테두리 색상 변경

- **입력**:
    - 현재 비밀번호: `password123!`
    - 새 비밀번호: `newPassword123!`
    - 새 비밀번호 확인: `differentPassword` (불일치)
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - 에러 메시지: `confirm-password-error` 표시
    - Input 테두리 스타일: 새 비밀번호 확인 입력창에 `border-red-500` 클래스 적용

### **TC005**: 현재 비밀번호가 틀린 경우 에러 메시지가 표시된다

- **입력**:
    - 현재 비밀번호: `password1234` (잘못된 비밀번호)
    - 새 비밀번호: `newPassword123!`
    - 새 비밀번호 확인: `newPassword123!`
- **이벤트**: 저장 버튼 클릭
- **예상 결과**: Alert 메시지 "현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요."

### **TC006**: 기존 비밀번호와 동일한 새 비밀번호 사용 시 에러 메시지가 표시된다

- **입력**:
    - 현재 비밀번호: `password123!`
    - 새 비밀번호: `password123!` (기존과 동일)
    - 새 비밀번호 확인: `password123!`
- **이벤트**: 저장 버튼 클릭
- **예상 결과**: Alert 메시지 "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."

### **TC007**: 정상적인 비밀번호 변경이 성공한다

- **입력**:
    - 현재 비밀번호: `password123!`
    - 새 비밀번호: `newPassword123!`
    - 새 비밀번호 확인: `newPassword123!`
- **이벤트**: 저장 버튼 클릭
- **예상 결과**: Alert 메시지 "비밀번호가 성공적으로 변경되었습니다."

### **TC008**: 비밀번호 수정을 취소할 수 있다

- **이벤트**: 취소 버튼 클릭
- **예상 결과**:
    - 현재 비밀번호 입력창 숨김
    - 비밀번호 수정 버튼(`password-edit-button`) 다시 표시

### **TC009**: 비밀번호 수정 모드일 때 이메일 수정 버튼이 숨겨진다

- **테스트 조건**: 비밀번호 수정 모드 진입
- **예상 결과**: 이메일 수정 버튼(`email-edit-button`) 비표시

## profile-edit 컴포넌트 단위 테스트 케이스
## **닉네임 유효성 검사**

### **TC001**: 닉네임이 비어있으면 중복 확인과 저장 버튼이 비활성화된다

- **이벤트**: 닉네임 입력창 내용 삭제
- **예상 결과**:
    - 중복 확인 버튼 비활성화
    - 저장 버튼 비활성화

### **TC002**: 닉네임을 입력하면 중복 확인 버튼이 활성화된다

- **입력**: `ㅇㅇ` (금칙어)
- **예상 결과**: 중복 확인 버튼 활성화

### **TC003**: 금칙어가 포함된 닉네임에 대해 에러 메시지가 표시된다

- **입력**: `ㅇㅇ` (금칙어)
- **이벤트**: 중복 확인 버튼 클릭
- **예상 결과**: Alert 메시지 "금칠어가 들어갔습니다. 다른 닉네임을 사용해주세요."

### **TC004**: 중복된 닉네임에 대해 에러 메시지가 표시된다

- **입력**: `선생님1` (중복 닉네임)
- **이벤트**: 중복 확인 버튼 클릭
- **예상 결과**: Alert 메시지 "현재 사용 중인 닉네임입니다."

### **TC005**: 사용 가능한 닉네임에 대해 성공 메시지가 표시되고 저장 버튼이 활성화된다

- **입력**: `선생님123` (사용 가능한 닉네임)
- **이벤트**: 중복 확인 버튼 클릭
- **예상 결과**:
    - Alert 메시지 "사용 가능한 닉네임입니다!"
    - 저장 버튼 활성화

## **과목 및 학교 선택**

### **TC006**: 과목 드롭다운이 올바르게 동작한다

- **초기 상태**: "수학" 선택됨
- **이벤트**: 과목 버튼 클릭 → "영어" 선택
- **예상 결과**: 과목 버튼 텍스트가 "영어"로 변경

### **TC007**: 학교 유형 선택이 올바르게 동작한다

- **초기 상태**:
    - 중학교 버튼: `bg-slate-800` 클래스 (선택됨)
    - 고등학교 버튼: `bg-slate-200` 클래스 (비선택)
- **이벤트**: 고등학교 버튼 클릭
- **예상 결과**:
    - 고등학교 버튼: `bg-slate-800` 클래스 (선택됨)
    - 중학교 버튼: `bg-slate-200` 클래스 (비선택)

## **프로필 저장**

### **TC008**: 프로필 정보 저장이 성공하면 API 요청이 발생하고 onChangeView가 호출된다

- **시나리오**:
    - 닉네임 변경: `새로운닉네임`
    - 중복 확인 완료
    - 과목 변경: 수학 → 영어
    - 학교 유형 변경: 중학교 → 고등학교
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - API 요청: `PATCH /api/v1/users/profile`
    - 요청 본문: `"nickname":"새로운닉네임"` 포함
    - `onChangeView` 콜백 함수 1회 호출

### **TC009**: 닉네임을 원래대로 되돌리면 중복 확인 없이도 저장할 수 있다

- **시나리오**:
    - 닉네임을 `임시변경`으로 변경
    - 다시 원래 닉네임 `이승섭`으로 되돌림
    - 중복 확인 없이 저장
- **이벤트**: 저장 버튼 클릭
- **예상 결과**:
    - API 요청: `PATCH /api/v1/users/profile` 호출
    - "닉네임 중복확인을 해주세요." Alert 메시지 **표시되지 않음**

## profile 기능 통합 테스트 케이스

### **TC001**: 비로그인 상태에서 마이페이지에 접근하면 로딩 스피너가 나오다가, 로그인 안내 메시지가 표시된다

- **테스트 조건**: 로그인하지 않은 상태에서 마이페이지 접근
- **시나리오**:
    - 초기 로딩 스피너(`animate-spin` 클래스) 표시
    - 로딩 완료 후 스피너 사라짐 (최대 3초 대기)
- **예상 결과**:
    - "로그인 후 접근 가능합니다." 텍스트 표시
    - 로그인 링크(`/login`)가 포함된 "로그인하기" 버튼 표시

### **TC002**: 로그인 상태에서는 프로필 정보가 정상적으로 표시된다

- **테스트 조건**: 사용자 로그인 완료 상태
- **시나리오**: 마이페이지 렌더링 및 로딩 완료 대기
- **예상 결과**:
    - "내 프로필" 제목 표시
    - "기본 정보" 섹션 표시
    - "인증 상태 :" 라벨 표시
    - "과목 :" 라벨 표시
    - "프로필 수정하기" 버튼 표시

### **TC003**: 프로필 수정하기 버튼을 누르면 profile-edit 컴포넌트가 정상적으로 렌더링된다

- **테스트 조건**: 로그인된 사용자 상태
- **이벤트**: "프로필 수정하기" 버튼 클릭
- **예상 결과**:
    - "닉네임" 라벨 표시
    - 닉네임 입력창(`닉네임을 입력하세요`) 표시
    - "학교" 라벨 표시
    - "중복 확인" 버튼 표시
    - "저장" 버튼 표시

### **TC004**: 프로필 수정하기에서 취소 버튼을 누르면 profile-view 컴포넌트가 정상적으로 렌더링된다

- **테스트 조건**: 로그인된 사용자 상태
- **시나리오**:
    - "프로필 수정하기" 버튼 클릭
    - "취소" 버튼 클릭
- **예상 결과**:
    - "내 프로필" 제목 표시
    - "인증 상태 :" 라벨 표시
    - "과목 :" 라벨 표시
    - "프로필 수정하기" 버튼 다시 표시

### **TC005**: 교사 미인증 유저가 교사 인증 필요 버튼을 클릭하면 이메일이 발송되었다는 모달창이 나온다

- **테스트 조건**: 교사 미인증 사용자 로그인 상태
- **이벤트**: "교사 인증 필요" 버튼 클릭
- **예상 결과**:
    - 모달 창(`role="dialog"`) 표시
    - "이메일이 발송되었습니다" 텍스트 표시
    - "확인" 버튼 클릭 후 모달 닫힘
    - "내 프로필" 화면으로 복귀

## 📸 스크린샷 (선택)

<img width="856" height="531" alt="스크린샷 2025-08-05 오후 7 02 52" src="https://github.com/user-attachments/assets/4dc62525-e02b-455d-aa91-b5cff73bab97" />

<img width="802" height="193" alt="스크린샷 2025-08-05 오후 7 03 05" src="https://github.com/user-attachments/assets/028e5a97-62cb-40b5-ab1c-ae09c699b9b6" />


[EDMT-354]: https://bbangbbangz.atlassian.net/browse/EDMT-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 테스트**
  * 프로필 이메일, 비밀번호, 프로필 수정 컴포넌트에 대한 단위 테스트가 추가되었습니다.
  * 마이페이지(프로필) 주요 기능에 대한 통합 테스트가 추가되었습니다.

* **버그 수정 및 개선**
  * 프로필 정보 조회 시 네트워크 오류 발생 시 1회 재시도하도록 개선되었습니다.

* **테스트 개선**
  * 로그인 테스트 유틸리티가 UI 시뮬레이션 방식에서 API 호출 방식으로 개선되었습니다.
  * 회원가입 및 로그인, 공지사항 관리자 테스트의 일부 설명 및 검증 방식이 변경되었습니다.

* **기타**
  * CI 환경에서 테스트 실행을 위한 npm 스크립트(test:ci)가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->